### PR TITLE
[DK-211] Username이 일치하지 않는 경우 A0001 에러 반환하도록 변경

### DIFF
--- a/src/test/java/com/kdt/team04/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/auth/service/AuthServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -22,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.team04.common.exception.BusinessException;
+import com.kdt.team04.common.exception.EntityNotFoundException;
 import com.kdt.team04.common.security.jwt.Jwt;
 import com.kdt.team04.common.security.jwt.JwtConfig;
 import com.kdt.team04.domain.auth.dto.AuthRequest;
@@ -103,6 +105,21 @@ class AuthServiceTest {
 
 		verify(userService, times(1)).findByUsername(userResponse.username());
 		verify(passwordEncoder, times(1)).matches(password, encodedPassword);
+	}
+
+	@Test
+	void testSignInWithNotFoundUser() {
+		//given
+		String password = "@Test1234";
+		String encodedPassword = "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.";
+		String notExistUsername = "noname";
+		UserResponse userResponse = new UserResponse(1L, "test00", encodedPassword, "nickname");
+		given(userService.findByUsername(notExistUsername)).willThrow(EntityNotFoundException.class);
+		//when, then
+		assertThatThrownBy(()->authService.signIn("noname", password)).isInstanceOf(BusinessException.class).hasMessageContaining(
+			MessageFormat.format("username : {0} not found", notExistUsername));
+
+		verify(userService, times(1)).findByUsername(notExistUsername);
 	}
 
 	@Test

--- a/src/test/java/com/kdt/team04/domain/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/user/controller/UserControllerIntegrationTest.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kdt.team04.common.ApiResponse;
+import com.kdt.team04.domain.security.WithMockJwtAuthentication;
 import com.kdt.team04.domain.user.dto.UserResponse;
 import com.kdt.team04.domain.user.entity.User;
 
@@ -48,6 +49,7 @@ class UserControllerIntegrationTest {
 	@Test
 	@Transactional
 	@DisplayName("회원 프로필을 조회한다.")
+	@WithMockJwtAuthentication
 	void testFindProfile() throws Exception {
 		// given
 		User newUser = new User("test00", "nk-test00", passwordEncoder.encode("1234"));
@@ -74,6 +76,7 @@ class UserControllerIntegrationTest {
 	@Test
 	@Transactional
 	@DisplayName("회원 프로필 닉네임이 포함된 유저들을 조회한다.")
+	@WithMockJwtAuthentication
 	void testFindAllByNickname() throws Exception {
 		// given
 		String nickname = "test";
@@ -108,6 +111,7 @@ class UserControllerIntegrationTest {
 	@Test
 	@Transactional
 	@DisplayName("닉네임이 포함된 사용자가 없다면 비어있는 리스트를 반환한다.")
+	@WithMockJwtAuthentication
 	void testFindAllByNicknameEmpty() throws Exception {
 		// given
 		String nickname = "notfound";
@@ -139,6 +143,7 @@ class UserControllerIntegrationTest {
 	@Test
 	@Transactional
 	@DisplayName("닉네임이 null 혹은 빈값으로 요청된다면 예외를 반환한다.")
+	@WithMockJwtAuthentication
 	void testFindAllByNicknameException() throws Exception {
 		// given
 		LongStream.range(1, 6)


### PR DESCRIPTION
## ✅  작업 단위

- [[DK-211] fix: 로그인할 때 username으로 유저 검색 실패 시 비밀번호가 맞지 않을때와 같은 에러 발생하도록 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/a14e1838e071ca60f1a4b08db5e64bf3751f9137)
  - 아이디가 틀렸는지, 패스워드가 틀렸는지 몰라야 합니다.
## 🤔 고민 했던 부분



## 🔊 HELP !!



[DK-211]: https://insta-kkyu.atlassian.net/browse/DK-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ