### PR TITLE
[DK-217] Http-Only Cookie, CORS 설정 수정

### DIFF
--- a/src/main/java/com/kdt/team04/common/config/WebMvcConfig.java
+++ b/src/main/java/com/kdt/team04/common/config/WebMvcConfig.java
@@ -20,6 +20,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		registry.addMapping(corsConfigProperties.api())
 			.allowedOrigins(corsConfigProperties.origin())
 			.allowedMethods(corsConfigProperties.method())
+			.allowCredentials(true).maxAge(3600)
 		;
 	}
 }

--- a/src/main/java/com/kdt/team04/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/kdt/team04/common/security/WebSecurityConfig.java
@@ -64,6 +64,7 @@ public class WebSecurityConfig {
 			.antMatchers(HttpMethod.PATCH, this.securityConfigProperties.patterns().permitAll().get("PATCH")).permitAll()
 			.antMatchers(HttpMethod.DELETE, this.securityConfigProperties.patterns().permitAll().get("DELETE")).permitAll()
 			.antMatchers(HttpMethod.PUT, this.securityConfigProperties.patterns().permitAll().get("PUT")).permitAll()
+			.antMatchers(HttpMethod.OPTIONS, this.securityConfigProperties.patterns().permitAll().get("OPTIONS")).permitAll()
 			.anyRequest().authenticated()
 			.and()
 			.formLogin()
@@ -81,7 +82,7 @@ public class WebSecurityConfig {
 			.sessionManagement()
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
-			.addFilterBefore(jwtAuthenticationFilter(jwt, tokenService), UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(jwtAuthenticationFilter(jwt, tokenService), UsernamePasswordAuthenticationFilter.class)
 		;
 
 		return http.build();

--- a/src/main/java/com/kdt/team04/domain/auth/dto/TokenDto.java
+++ b/src/main/java/com/kdt/team04/domain/auth/dto/TokenDto.java
@@ -1,4 +1,4 @@
 package com.kdt.team04.domain.auth.dto;
 
-public record TokenDto(String header, String token) {
+public record TokenDto(String header, String token, int expirySecond) {
 }

--- a/src/main/java/com/kdt/team04/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kdt/team04/domain/auth/service/AuthService.java
@@ -65,8 +65,8 @@ public class AuthService {
 			foundUser.id(),
 			username,
 			foundUser.nickname(),
-			new TokenDto(this.jwt.accessTokenProperties().header(), accessToken),
-			new TokenDto(this.jwt.refreshTokenProperties().header(), refreshToken),
+			new TokenDto(this.jwt.accessTokenProperties().header(), accessToken, this.jwt.accessTokenProperties().expirySeconds()),
+			new TokenDto(this.jwt.refreshTokenProperties().header(), refreshToken, this.jwt.accessTokenProperties().expirySeconds()),
 			authenticationToken
 		);
 	}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -6,14 +6,9 @@ spring:
     url: ENC(9d/4bHB1HmtQc/9cqFnK/mWXll5mHPVs1V1JBqNjyCTNZzj2CE62LTe7mWKNhCW1FK8Zh0JPGiFj8ICXRlCl65pco0f/r7TTLqJGYKeMDln1QkZRmttdcg==)
   jpa:
     show-sql: false
-
 logging:
   level:
     org.hibernate.type.descriptor.sql: INFO
-
-cors:
-  allowed:
-    origin: "http://localhost:3000"
 jwt:
   client-secret: ENC(vaOuavM8/QZzrntUSL/CLC3Q47399EsR)
 encryptor:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -12,11 +12,6 @@ spring:
 logging:
   level:
     com.kdt: DEBUG
-    org.hibernate.type.descriptor.sql: DEBUG
-
-cors:
-  allowed:
-    origin: http://localhost:3000
-
+    org.hibernate.type.descriptor.sql: DEBUG\
 jwt:
   client-secret: ${JWT_SECRET:DEFAULT_JWT_SECRET}

--- a/src/main/resources/application-mem.yml
+++ b/src/main/resources/application-mem.yml
@@ -19,9 +19,5 @@ logging:
   level:
     com.kdt: DEBUG
     org.hibernate.type.descriptor.sql: DEBUG
-
-cors:
-  allowed:
-    origin: http://localhost:3000
 jwt:
   client-secret: ${JWT_SECRET:DEFAULT_JWT_SECRET}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,5 @@
 server:
   port: ${PORT:8080}
-
 spring:
   jpa:
     hibernate:
@@ -11,8 +10,11 @@ spring:
     locations: classpath:db/migration, classpath:db/seed
 cors:
   allowed:
-    api: /api/**
+    api: /**
     method: '*'
+    origin:
+      - http://localhost:3000
+      - http://127.0.0.1:3000
 security:
   patterns:
     ignoring:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,7 @@ security:
       PATCH: [ ]
       PUT: [ ]
       DELETE: [ ]
+      OPTIONS: /**
 jwt:
   issuer: sfam
   client-secret:

--- a/src/test/java/com/kdt/team04/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/kdt/team04/domain/auth/controller/AuthControllerTest.java
@@ -77,8 +77,8 @@ class AuthControllerTest {
 			user.getId(),
 			username,
 			user.getNickname(),
-			new TokenDto("accessToken", "accessToken"),
-			new TokenDto("refreshToken", "refreshToken"),
+			new TokenDto("accessToken", "accessToken", 3600),
+			new TokenDto("refreshToken", "refreshToken", 3600),
 			new JwtAuthenticationToken(new JwtAuthentication("accessToken", user.getId(), username),
 				null,
 				authorities


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-198] setting: .yaml 설정 파일 - CORS 정보 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/bf67ed861de72693cf5228e4d668d5c47ce6e67b)
- mem, local, dev 기존 cors-origin 설정을 모두 메인 설정으로 이동했습니다.
  변경사항이 생기면 그때 다시 조정하는게 어떨까 싶네요. 🤔
- origin에 루프백(http://127.0.0.1:3000)도 추가했습니다.

### [[DK-198] feat: Auth - Http-Only 쿠키로 반환되도록 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/a5f079368a47c19c5a108263fc7761152106a267)
- TokenDto에 만료시간 추가 후 로그인때 쿠키 만료 설정 후 반환되도록 수정
- 반환 쿠키에 HttpOnly, secure 속성도 추가

### [[DK-198] setting: CORS 설정 수정(OPTIONS Method 허용 처리, credentials 부분 추가)](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/383f09e81445aa571308423f172f7655e745d643)
- CORS 설정을 위해서 OPTIONS 메소드 허용으로 설정, Credentials 설정 추가

[DK-198]: https://insta-kkyu.atlassian.net/browse/DK-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-198]: https://insta-kkyu.atlassian.net/browse/DK-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-198]: https://insta-kkyu.atlassian.net/browse/DK-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ