### PR TITLE
[DK-218] 팀 초대 수락 API 구현 

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -22,11 +22,15 @@ public enum ErrorCode {
 	USER_NOT_FOUND("U0001", "Not found user", HttpStatus.NOT_FOUND),
 
 	//TOKEN
-	TOKEN_NOT_FOUND("A0001", "Not found token", HttpStatus.NOT_FOUND),
+	TOKEN_NOT_FOUND("A0002", "Not found token", HttpStatus.NOT_FOUND),
 
 	//TEAM
 	TEAM_NOT_FOUND("T0001", "Not found team", HttpStatus.NOT_FOUND),
 	NOT_TEAM_LEADER("T0002", "Not team leader", HttpStatus.FORBIDDEN),
+
+	//TEAM_INVITATION
+	TEAM_INVITATION_NOT_FOUND("I001", "Not found invitation", HttpStatus.NOT_FOUND),
+	INVALID_INVITATION("I0002", "Invalid invitation", HttpStatus.BAD_REQUEST),
 
 	//TEAM_MEMBER
 	ALREADY_TEAM_MEMBER("M0001", "Already member of team" , HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -15,21 +15,19 @@ public enum ErrorCode {
 	DOMAIN_EXCEPTION("V0003", "Domain constraint violation", HttpStatus.BAD_REQUEST),
 	DATA_INTEGRITY_VIOLATION("V0004", "Data integrity violation", HttpStatus.BAD_REQUEST),
 
-	//AUTHENTICATION
+	//AUTHENTICATION & TOKEN
 	AUTHENTICATION_FAILED("A0001", "Authentication failed", HttpStatus.BAD_REQUEST),
+	TOKEN_NOT_FOUND("A0002", "Not found token", HttpStatus.NOT_FOUND),
 
 	//USER
 	USER_NOT_FOUND("U0001", "Not found user", HttpStatus.NOT_FOUND),
-
-	//TOKEN
-	TOKEN_NOT_FOUND("A0002", "Not found token", HttpStatus.NOT_FOUND),
 
 	//TEAM
 	TEAM_NOT_FOUND("T0001", "Not found team", HttpStatus.NOT_FOUND),
 	NOT_TEAM_LEADER("T0002", "Not team leader", HttpStatus.FORBIDDEN),
 
 	//TEAM_INVITATION
-	TEAM_INVITATION_NOT_FOUND("I001", "Not found invitation", HttpStatus.NOT_FOUND),
+	TEAM_INVITATION_NOT_FOUND("I0001", "Not found invitation", HttpStatus.NOT_FOUND),
 	INVALID_INVITATION("I0002", "Invalid invitation", HttpStatus.BAD_REQUEST),
 
 	//TEAM_MEMBER

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
@@ -1,0 +1,35 @@
+package com.kdt.team04.domain.team.service;
+
+import java.text.MessageFormat;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kdt.team04.common.exception.EntityNotFoundException;
+import com.kdt.team04.common.exception.ErrorCode;
+import com.kdt.team04.domain.team.dto.TeamConverter;
+import com.kdt.team04.domain.team.dto.TeamResponse;
+import com.kdt.team04.domain.team.entity.Team;
+import com.kdt.team04.domain.team.repository.TeamRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class TeamGiverService {
+
+	private final TeamRepository teamRepository;
+	private final TeamConverter teamConverter;
+
+	public TeamGiverService(TeamRepository teamRepository, TeamConverter teamConverter) {
+		this.teamRepository = teamRepository;
+		this.teamConverter = teamConverter;
+	}
+
+	public TeamResponse findById(Long id) {
+		Team team = teamRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.TEAM_NOT_FOUND,
+				MessageFormat.format("TeamId = {0}", id)));
+
+		return teamConverter.toTeamResponse(team);
+	}
+
+}

--- a/src/main/java/com/kdt/team04/domain/teaminvitation/entity/TeamInvitation.java
+++ b/src/main/java/com/kdt/team04/domain/teaminvitation/entity/TeamInvitation.java
@@ -66,4 +66,9 @@ public class TeamInvitation {
 	public InvitationStatus getStatus() {
 		return status;
 	}
+
+	public void accept() {
+		this.status = InvitationStatus.ACCEPTED;
+	}
+
 }

--- a/src/main/java/com/kdt/team04/domain/teaminvitation/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/kdt/team04/domain/teaminvitation/repository/TeamInvitationRepository.java
@@ -1,8 +1,14 @@
 package com.kdt.team04.domain.teaminvitation.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.kdt.team04.domain.teaminvitation.entity.InvitationStatus;
 import com.kdt.team04.domain.teaminvitation.entity.TeamInvitation;
 
 public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long> {
+	boolean existsByTeamIdAndTargetIdAndStatus(Long teamId, Long targetId, InvitationStatus status);
+
+	Optional<TeamInvitation> findByTeamIdAndTargetId(Long teamId, Long teagetId);
 }

--- a/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationGiverService.java
@@ -1,0 +1,32 @@
+package com.kdt.team04.domain.teaminvitation.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kdt.team04.common.exception.EntityNotFoundException;
+import com.kdt.team04.common.exception.ErrorCode;
+import com.kdt.team04.domain.teaminvitation.entity.InvitationStatus;
+import com.kdt.team04.domain.teaminvitation.repository.TeamInvitationRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class TeamInvitationGiverService {
+	private final TeamInvitationRepository teamInvitationRepository;
+
+	public TeamInvitationGiverService(
+		TeamInvitationRepository teamInvitationRepository) {
+		this.teamInvitationRepository = teamInvitationRepository;
+	}
+
+	public boolean existsTeamInvitation(Long teamId, Long targetId, InvitationStatus status) {
+		return teamInvitationRepository.existsByTeamIdAndTargetIdAndStatus(teamId, targetId, status);
+	}
+
+	@Transactional
+	public void accept(Long teamId, Long targetId) {
+		teamInvitationRepository.findByTeamIdAndTargetId(teamId, targetId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.TEAM_INVITATION_NOT_FOUND))
+			.accept();
+	}
+
+}

--- a/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationService.java
+++ b/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationService.java
@@ -12,11 +12,11 @@ import com.kdt.team04.domain.team.dto.TeamConverter;
 import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.team.service.TeamService;
-import com.kdt.team04.domain.teaminvitation.dto.TeamInvitationRequest;
 import com.kdt.team04.domain.teaminvitation.dto.TeamInvitationResponse;
 import com.kdt.team04.domain.teaminvitation.entity.InvitationStatus;
 import com.kdt.team04.domain.teaminvitation.entity.TeamInvitation;
 import com.kdt.team04.domain.teaminvitation.repository.TeamInvitationRepository;
+import com.kdt.team04.domain.teammember.service.TeamMemberGiverService;
 import com.kdt.team04.domain.teammember.service.TeamMemberService;
 import com.kdt.team04.domain.user.UserConverter;
 import com.kdt.team04.domain.user.dto.UserResponse;
@@ -31,23 +31,23 @@ public class TeamInvitationService {
 	private final UserService userService;
 	private final TeamConverter teamConverter;
 	private final UserConverter userConverter;
-	private final TeamMemberService teamMemberService;
+	private final TeamMemberGiverService teamMemberGiverService;
 	private final TeamService teamService;
 
 	public TeamInvitationService(TeamInvitationRepository teamInvitationRepository,
 		UserService userService, TeamConverter teamConverter, UserConverter userConverter,
-		TeamMemberService teamMemberService, TeamService teamService) {
+		TeamMemberGiverService teamMemberGiverService, TeamService teamService) {
 		this.teamInvitationRepository = teamInvitationRepository;
 		this.userService = userService;
 		this.teamConverter = teamConverter;
 		this.userConverter = userConverter;
-		this.teamMemberService = teamMemberService;
+		this.teamMemberGiverService = teamMemberGiverService;
 		this.teamService = teamService;
 	}
 
 	@Transactional
 	public TeamInvitationResponse.InviteResponse invite(Long myId, Long teamId, Long targetUserId) {
-		if (teamMemberService.existsTeamMember(teamId, targetUserId)) {
+		if (teamMemberGiverService.existsTeamMember(teamId, targetUserId)) {
 			throw new BusinessException(ErrorCode.ALREADY_TEAM_MEMBER,
 				MessageFormat.format("teamId = {0}, userId = {1}", teamId, targetUserId));
 		}
@@ -66,4 +66,5 @@ public class TeamInvitationService {
 
 		return new TeamInvitationResponse.InviteResponse(savedInvitationId);
 	}
+
 }

--- a/src/main/java/com/kdt/team04/domain/teammember/controller/TeamMemberController.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/controller/TeamMemberController.java
@@ -2,6 +2,7 @@ package com.kdt.team04.domain.teammember.controller;
 
 import javax.validation.Valid;
 
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,8 +11,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.kdt.team04.domain.teammember.dto.TeamMemberRequest;
 import com.kdt.team04.domain.teammember.service.TeamMemberService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "팀원 관리 API")
 @RestController
-@RequestMapping("/api/teams/members")
+@RequestMapping("/api/teams/{teamId}/members")
 public class TeamMemberController {
 
 	private final TeamMemberService teamMemberService;
@@ -21,8 +26,9 @@ public class TeamMemberController {
 	}
 
 	@PostMapping
-	public void registerMember(@RequestBody @Valid TeamMemberRequest.RegisterRequest registerRequest) {
-		teamMemberService.registerTeamMember(registerRequest);
+	@Operation(summary = "팀원 등록", description = "팀 아이디와 등록 대상 유저 ID를 받아 팀원에 등록합니다.")
+	public void registerMember(@PathVariable Long teamId, @RequestBody @Valid TeamMemberRequest.RegisterRequest registerRequest) {
+		teamMemberService.registerTeamMember(teamId, registerRequest);
 	}
 
 }

--- a/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberConverter.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberConverter.java
@@ -11,15 +11,15 @@ import com.kdt.team04.domain.user.entity.User;
 @Component
 public class TeamMemberConverter {
 
-	public User toUser(UserResponse userResponse) {
-		return new User(userResponse.id(), userResponse.password(), userResponse.username(), userResponse.nickname());
+	public User toUser(Long userId) {
+		return User.builder()
+			.id(userId)
+			.build();
 	}
 
-	public Team toTeam(TeamResponse response) {
+	public Team toTeam(Long teamId) {
 		return Team.builder()
-			.id(response.id())
-			.name(response.teamName())
-			.description(response.description())
+			.id(teamId)
 			.build();
 	}
 

--- a/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberRequest.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberRequest.java
@@ -7,10 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class TeamMemberRequest {
 
 	public record RegisterRequest(
-		@Schema(description = "팀 아이디", required = true)
-		@NotNull(message = "팀 아이디는 필수입니다.")
-		Long teamId,
-
 		@Schema(description = "팀원 아이디", required = true)
 		@NotNull(message = "유저 아이디는 필수입니다.")
 		Long userId) {

--- a/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberResponse.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberResponse.java
@@ -2,9 +2,14 @@ package com.kdt.team04.domain.teammember.dto;
 
 import com.kdt.team04.domain.teammember.entity.TeamMemberRole;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record TeamMemberResponse(
+	@Schema(description = "팀원의 아이디")
 	Long userId,
+	@Schema(description = "팀원의 닉네임")
 	String nickname,
+	@Schema(description = "팀원의 권한")
 	TeamMemberRole role
 ) {
 

--- a/src/main/java/com/kdt/team04/domain/teammember/service/TeamMemberGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/service/TeamMemberGiverService.java
@@ -5,13 +5,16 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.teammember.dto.TeamMemberConverter;
 import com.kdt.team04.domain.teammember.dto.TeamMemberResponse;
 import com.kdt.team04.domain.teammember.entity.TeamMember;
+import com.kdt.team04.domain.teammember.entity.TeamMemberRole;
 import com.kdt.team04.domain.teammember.repository.TeamMemberRepository;
+import com.kdt.team04.domain.user.entity.User;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class TeamMemberGiverService {
 
 	private final TeamMemberRepository teamMemberRepository;
@@ -29,4 +32,18 @@ public class TeamMemberGiverService {
 			.map(teamMemberConverter::toTeamMemberResponse)
 			.toList();
 	}
+
+	public boolean existsTeamMember(Long teamId, Long userId) {
+		return teamMemberRepository.existsByTeamIdAndUserId(teamId, userId);
+	}
+
+	@Transactional
+	public void registerTeamLeader(Long teamId, Long userId) {
+		User user = teamMemberConverter.toUser(userId);
+		Team team = teamMemberConverter.toTeam(teamId);
+
+		TeamMember teamMember = new TeamMember(team, user, TeamMemberRole.LEADER);
+		teamMemberRepository.save(teamMember);
+	}
+
 }

--- a/src/main/java/com/kdt/team04/domain/user/entity/User.java
+++ b/src/main/java/com/kdt/team04/domain/user/entity/User.java
@@ -12,6 +12,8 @@ import javax.validation.constraints.Size;
 
 import com.kdt.team04.domain.BaseEntity;
 
+import lombok.Builder;
+
 @Table(name = "users")
 @Entity
 public class User extends BaseEntity {
@@ -41,6 +43,7 @@ public class User extends BaseEntity {
 		this(null, password, username, nickname);
 	}
 
+	@Builder
 	public User(Long id, String password, String username, String nickname) {
 		this.id = id;
 		this.password = password;

--- a/src/main/resources/db/migration/V3_1__Alter_team_auto_increment.sql
+++ b/src/main/resources/db/migration/V3_1__Alter_team_auto_increment.sql
@@ -1,0 +1,13 @@
+ALTER TABLE match_record DROP FOREIGN KEY match_record_ibfk_3;
+ALTER TABLE match_request DROP FOREIGN KEY match_request_ibfk_3;
+ALTER TABLE matches DROP FOREIGN KEY matches_ibfk_2;
+ALTER TABLE team_invitation DROP FOREIGN KEY team_invitation_ibfk_1;
+ALTER TABLE team_member DROP FOREIGN KEY team_member_ibfk_1;
+
+ALTER TABLE team MODIFY id BIGINT NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE match_record ADD FOREIGN KEY(team_id) REFERENCES team(id);
+ALTER TABLE match_request ADD FOREIGN KEY(team_id) REFERENCES team(id);
+ALTER TABLE matches ADD FOREIGN KEY(team_id) REFERENCES team(id);
+ALTER TABLE team_invitation ADD FOREIGN KEY(team_id) REFERENCES team(id);
+ALTER TABLE team_member ADD FOREIGN KEY(team_id) REFERENCES team(id);

--- a/src/test/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.team04.common.exception.BusinessException;
@@ -94,34 +95,35 @@ class TeamInvitationServiceTest {
 			.isInstanceOf(BusinessException.class);
 	}
 
-	// @Test
-	// @DisplayName("이미 초대를 보냈으면 초대할 수 없다.")
-	// void testInviteAlreadySendInviteFail() {
-	// 	//given
-	// 	User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
-	// 	User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
-	//
-	// 	entityManager.persist(userA);
-	// 	entityManager.persist(userB);
-	// 	Team team = Team.builder()
-	// 		.name("teamA")
-	// 		.description("description")
-	// 		.sportsCategory(SportsCategory.BADMINTON)
-	// 		.leader(userA)
-	// 		.build();
-	//
-	// 	entityManager.persist(team);
-	// 	TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
-	// 	entityManager.persist(teamMemberA);
-	// 	entityManager.flush();
-	// 	entityManager.clear();
-	// 	TeamInvitationRequest teamInvitationRequest = new TeamInvitationRequest(userB.getId());
-	// 	teamInvitationService.invite(userA.getId(), team.getId(), teamInvitationRequest.targetUserId());
-	// 	teamInvitationService.invite(userA.getId(), team.getId(), teamInvitationRequest.targetUserId());
-	//
-	// 	//when, then
-	// 	Assertions.assertThatThrownBy(() -> entityManager.flush()).isInstanceOf(PersistenceException.class);
-	// }
+	@Test
+	@DisplayName("이미 초대를 보냈으면 초대할 수 없다.")
+	void testInviteAlreadySendInviteFail() {
+		//given
+		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+
+		entityManager.persist(userA);
+		entityManager.persist(userB);
+		Team team = Team.builder()
+			.name("teamA")
+			.description("description")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(userA)
+			.build();
+
+		entityManager.persist(team);
+		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
+		entityManager.persist(teamMemberA);
+		entityManager.flush();
+		entityManager.clear();
+		TeamInvitationRequest teamInvitationRequest = new TeamInvitationRequest(userB.getId());
+		teamInvitationService.invite(userA.getId(), team.getId(), teamInvitationRequest.targetUserId());
+
+		//when, then
+		Assertions.assertThatThrownBy(() ->
+			teamInvitationService.invite(userA.getId(), team.getId(), teamInvitationRequest.targetUserId())
+		).isInstanceOf(DataIntegrityViolationException.class);
+	}
 
 	@Test
 	@DisplayName("팀 리더가 아닌사람은 초대할 수 없다.")

--- a/src/test/java/com/kdt/team04/domain/teammember/service/TeamMemberServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/teammember/service/TeamMemberServiceTest.java
@@ -1,0 +1,128 @@
+package com.kdt.team04.domain.teammember.service;
+
+import javax.persistence.EntityManager;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kdt.team04.common.exception.BusinessException;
+import com.kdt.team04.domain.team.SportsCategory;
+import com.kdt.team04.domain.team.entity.Team;
+import com.kdt.team04.domain.teaminvitation.entity.InvitationStatus;
+import com.kdt.team04.domain.teaminvitation.entity.TeamInvitation;
+import com.kdt.team04.domain.teammember.dto.TeamMemberRequest;
+import com.kdt.team04.domain.teammember.entity.TeamMember;
+import com.kdt.team04.domain.teammember.entity.TeamMemberRole;
+import com.kdt.team04.domain.user.entity.User;
+
+@SpringBootTest
+@Transactional
+class TeamMemberServiceTest {
+
+	@Autowired
+	TeamMemberService teamMemberService;
+
+	@Autowired
+	EntityManager entityManager;
+
+	@Test
+	@DisplayName("팀원 등록에 성공한다.")
+	void testRegisterMember() {
+		//given
+		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		entityManager.persist(userA);
+		entityManager.persist(userB);
+
+		Team team = Team.builder()
+			.name("teamA")
+			.description("description")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(userA)
+			.build();
+		entityManager.persist(team);
+
+		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
+		entityManager.persist(teamMemberA);
+		TeamInvitation teamInvitationA = new TeamInvitation(team, userB, InvitationStatus.WAITING);
+		entityManager.persist(teamInvitationA);
+		entityManager.flush();
+
+		// when
+		TeamMemberRequest.RegisterRequest request = new TeamMemberRequest.RegisterRequest(userB.getId());
+		teamMemberService.registerTeamMember(team.getId(), request);
+
+		// then
+		Assertions.assertThat(teamMemberService.existsTeamMember(team.getId(), userB.getId())).isTrue();
+	}
+
+	@Test
+	@DisplayName("이미 등록된 팀원은 등록에 실패한다.")
+	void testAlreadyMember() {
+		//given
+		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		entityManager.persist(userA);
+		entityManager.persist(userB);
+
+		Team team = Team.builder()
+			.name("teamA")
+			.description("description")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(userA)
+			.build();
+		entityManager.persist(team);
+
+		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
+		entityManager.persist(teamMemberA);
+
+		// 팀 맴버에 이미 등록
+		TeamMember teamMemberB = new TeamMember(team, userB, TeamMemberRole.MEMBER);
+		entityManager.persist(teamMemberB);
+		entityManager.flush();
+
+		// when
+		TeamMemberRequest.RegisterRequest request = new TeamMemberRequest.RegisterRequest(userB.getId());
+
+		// then
+		Assertions.assertThatThrownBy(() -> teamMemberService.registerTeamMember(team.getId(), request))
+			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	@DisplayName("초대 상태가 WAITING 상태가 아니라면 등록에 실패한다.")
+	void testInvalidInvitation() {
+		//given
+		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		entityManager.persist(userA);
+		entityManager.persist(userB);
+
+		Team team = Team.builder()
+			.name("teamA")
+			.description("description")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(userA)
+			.build();
+		entityManager.persist(team);
+
+		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
+		entityManager.persist(teamMemberA);
+
+		// 이미 수락한 상태라면
+		TeamInvitation teamInvitationA = new TeamInvitation(team, userB, InvitationStatus.ACCEPTED);
+		entityManager.persist(teamInvitationA);
+
+		// when
+		TeamMemberRequest.RegisterRequest request = new TeamMemberRequest.RegisterRequest(userB.getId());
+
+		// then
+		Assertions.assertThatThrownBy(() -> teamMemberService.registerTeamMember(team.getId(), request))
+			.isInstanceOf(BusinessException.class);
+	}
+
+}


### PR DESCRIPTION
## ✅  작업 단위

- 팀 초대 수락 API 기능 구현했습니다.
  - 다른 분들의 도메인도 조금씩 건드리고 메서드 만든게 있어서 제가 실수를 했을 가능성이 있을 것 같아요 조금 더 자세히 봐주시면 감사드리겠습니다 ㅠ
 
-  진형님이 작성하신 팀 초대 테스트코드 엔티티 기본키 생성전략 Identity로 변경 후 깨지는 부분 수정했습니다.
-  팀 초대 수락 테스트코드 작성했습니다.
-  유저에 빌더 애노테이션을 추가했습니다.

## 🤔 고민 했던 부분

## 🔊 HELP !!
