### PR TITLE
[Dk-215] 팀 생성 및 팀 프로필 조회

### DIFF
--- a/src/main/java/com/kdt/team04/domain/match/review/dto/MatchRecordResponse.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/dto/MatchRecordResponse.java
@@ -1,0 +1,7 @@
+package com.kdt.team04.domain.match.review.dto;
+
+public record MatchRecordResponse() {
+	public record TotalCount(int win, int draw, int lose) {
+
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/dto/MatchReviewResponse.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/dto/MatchReviewResponse.java
@@ -1,0 +1,6 @@
+package com.kdt.team04.domain.match.review.dto;
+
+public record MatchReviewResponse(){
+	public record TotalCount(int bestCount, int likeCount, int dislikeCount){
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/entity/MatchRecord.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/entity/MatchRecord.java
@@ -18,6 +18,8 @@ import com.kdt.team04.domain.match.post.entity.Match;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.user.entity.User;
 
+import lombok.Builder;
+
 @Entity
 public class MatchRecord extends BaseEntity {
 
@@ -42,6 +44,7 @@ public class MatchRecord extends BaseEntity {
 
 	protected MatchRecord() {/*no-op*/}
 
+	@Builder
 	public MatchRecord(Long id, Match match, User user, Team team, MatchRecordValue result) {
 		this.id = id;
 		this.match = match;

--- a/src/main/java/com/kdt/team04/domain/match/review/entity/MatchReview.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/entity/MatchReview.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.kdt.team04.domain.BaseEntity;
 import com.kdt.team04.domain.match.post.entity.Match;
+import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.user.entity.User;
 
 @Entity
@@ -35,13 +36,29 @@ public class MatchReview extends BaseEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "team_id")
+	private Team team;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "target_user_id")
+	private User targetUser;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "target_team_id")
+	private Team targetTeam;
+
 	protected MatchReview() {/*no-op*/}
 
-	public MatchReview(Long id, Match match, MatchReviewValue review, User user) {
+	public MatchReview(Long id, Match match, MatchReviewValue review, User user, Team team, User targetUser,
+		Team targetTeam) {
 		this.id = id;
 		this.match = match;
 		this.review = review;
 		this.user = user;
+		this.team = team;
+		this.targetUser = targetUser;
+		this.targetTeam = targetTeam;
 	}
 
 	public Long getId() {
@@ -60,6 +77,18 @@ public class MatchReview extends BaseEntity {
 		return user;
 	}
 
+	public Team getTeam() {
+		return team;
+	}
+
+	public User getTargetUser() {
+		return targetUser;
+	}
+
+	public Team getTargetTeam() {
+		return targetTeam;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
@@ -67,6 +96,9 @@ public class MatchReview extends BaseEntity {
 			.append("match", match)
 			.append("review", review)
 			.append("user", user)
+			.append("team", team)
+			.append("targetUser", targetUser)
+			.append("targetTeam", targetTeam)
 			.toString();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepository.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepository.java
@@ -1,0 +1,8 @@
+package com.kdt.team04.domain.match.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kdt.team04.domain.match.review.entity.MatchRecord;
+
+public interface MatchRecordRepository extends JpaRepository<MatchRecord, Long>, MatchRecordRepositoryCustom {
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryCustom.java
@@ -3,5 +3,5 @@ package com.kdt.team04.domain.match.review.repository;
 import com.kdt.team04.domain.match.review.dto.MatchRecordResponse;
 
 public interface MatchRecordRepositoryCustom {
-	MatchRecordResponse.TotalCount getTotalCount(Long teamId);
+	MatchRecordResponse.TotalCount getTeamTotalCount(Long teamId);
 }

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.kdt.team04.domain.match.review.repository;
+
+import com.kdt.team04.domain.match.review.dto.MatchRecordResponse;
+
+public interface MatchRecordRepositoryCustom {
+	MatchRecordResponse.TotalCount getTotalCount(Long teamId);
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryImpl.java
@@ -19,7 +19,7 @@ public class MatchRecordRepositoryImpl implements MatchRecordRepositoryCustom {
 	}
 
 	@Override
-	public MatchRecordResponse.TotalCount getTotalCount(Long teamId) {
+	public MatchRecordResponse.TotalCount getTeamTotalCount(Long teamId) {
 		return queryFactory
 			.select(Projections.constructor(MatchRecordResponse.TotalCount.class,
 				matchRecord.result.when(MatchRecordValue.WIN).then(1).otherwise(0).sum(),

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchRecordRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.kdt.team04.domain.match.review.repository;
+
+import static com.kdt.team04.domain.match.review.entity.QMatchRecord.matchRecord;
+
+import org.springframework.stereotype.Repository;
+
+import com.kdt.team04.domain.match.review.dto.MatchRecordResponse;
+import com.kdt.team04.domain.match.review.entity.MatchRecordValue;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Repository
+public class MatchRecordRepositoryImpl implements MatchRecordRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	public MatchRecordRepositoryImpl(JPAQueryFactory queryFactory) {
+		this.queryFactory = queryFactory;
+	}
+
+	@Override
+	public MatchRecordResponse.TotalCount getTotalCount(Long teamId) {
+		return queryFactory
+			.select(Projections.constructor(MatchRecordResponse.TotalCount.class,
+				matchRecord.result.when(MatchRecordValue.WIN).then(1).otherwise(0).sum(),
+				matchRecord.result.when(MatchRecordValue.DRAW).then(1).otherwise(0).sum(),
+				matchRecord.result.when(MatchRecordValue.LOSE).then(1).otherwise(0).sum()
+			))
+			.from(matchRecord)
+			.where(matchRecord.team.id.eq(teamId))
+			.fetchOne();
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepository.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepository.java
@@ -1,0 +1,8 @@
+package com.kdt.team04.domain.match.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kdt.team04.domain.match.review.entity.MatchReview;
+
+public interface MatchReviewRepository extends JpaRepository<MatchReview, Long>, MatchReviewRepositoryCustom {
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryCustom.java
@@ -3,5 +3,5 @@ package com.kdt.team04.domain.match.review.repository;
 import com.kdt.team04.domain.match.review.dto.MatchReviewResponse;
 
 public interface MatchReviewRepositoryCustom {
-	MatchReviewResponse.TotalCount getTotalCount(Long teamId);
+	MatchReviewResponse.TotalCount getTeamTotalCount(Long teamId);
 }

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.kdt.team04.domain.match.review.repository;
+
+import com.kdt.team04.domain.match.review.dto.MatchReviewResponse;
+
+public interface MatchReviewRepositoryCustom {
+	MatchReviewResponse.TotalCount getTotalCount(Long teamId);
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.kdt.team04.domain.match.review.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.kdt.team04.domain.match.review.dto.MatchReviewResponse;
+import com.kdt.team04.domain.match.review.entity.MatchReviewValue;
+import com.kdt.team04.domain.match.review.entity.QMatchReview;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Repository
+public class MatchReviewRepositoryImpl implements MatchReviewRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public MatchReviewRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public MatchReviewResponse.TotalCount getTotalCount(Long teamId) {
+		return jpaQueryFactory.select(Projections.constructor(MatchReviewResponse.TotalCount.class,
+				QMatchReview.matchReview.review.when(MatchReviewValue.BEST).then(1).otherwise(0),
+				QMatchReview.matchReview.review.when(MatchReviewValue.LIKE).then(1).otherwise(0),
+				QMatchReview.matchReview.review.when(MatchReviewValue.DISLIKE).then(1).otherwise(0)))
+			.from(QMatchReview.matchReview)
+			.where(QMatchReview.matchReview.id.eq(teamId))
+			.fetchOne();
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/repository/MatchReviewRepositoryImpl.java
@@ -1,10 +1,11 @@
 package com.kdt.team04.domain.match.review.repository;
 
+import static com.kdt.team04.domain.match.review.entity.QMatchReview.matchReview;
+
 import org.springframework.stereotype.Repository;
 
 import com.kdt.team04.domain.match.review.dto.MatchReviewResponse;
 import com.kdt.team04.domain.match.review.entity.MatchReviewValue;
-import com.kdt.team04.domain.match.review.entity.QMatchReview;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -18,13 +19,15 @@ public class MatchReviewRepositoryImpl implements MatchReviewRepositoryCustom {
 	}
 
 	@Override
-	public MatchReviewResponse.TotalCount getTotalCount(Long teamId) {
-		return jpaQueryFactory.select(Projections.constructor(MatchReviewResponse.TotalCount.class,
-				QMatchReview.matchReview.review.when(MatchReviewValue.BEST).then(1).otherwise(0),
-				QMatchReview.matchReview.review.when(MatchReviewValue.LIKE).then(1).otherwise(0),
-				QMatchReview.matchReview.review.when(MatchReviewValue.DISLIKE).then(1).otherwise(0)))
-			.from(QMatchReview.matchReview)
-			.where(QMatchReview.matchReview.id.eq(teamId))
+	public MatchReviewResponse.TotalCount getTeamTotalCount(Long teamId) {
+		return jpaQueryFactory
+			.select(Projections.constructor(MatchReviewResponse.TotalCount.class,
+				matchReview.review.when(MatchReviewValue.BEST).then(1).otherwise(0).sum(),
+				matchReview.review.when(MatchReviewValue.LIKE).then(1).otherwise(0).sum(),
+				matchReview.review.when(MatchReviewValue.DISLIKE).then(1).otherwise(0).sum()
+			))
+			.from(matchReview)
+			.where(matchReview.targetTeam.id.eq(teamId))
 			.fetchOne();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/match/review/service/MatchRecordGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/service/MatchRecordGiverService.java
@@ -15,6 +15,6 @@ public class MatchRecordGiverService {
 	}
 
 	public MatchRecordResponse.TotalCount findByTeamTotalRecord(Long id) {
-		return matchRecordRepository.getTotalCount(id);
+		return matchRecordRepository.getTeamTotalCount(id);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/match/review/service/MatchRecordGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/service/MatchRecordGiverService.java
@@ -1,0 +1,20 @@
+package com.kdt.team04.domain.match.review.service;
+
+import org.springframework.stereotype.Service;
+
+import com.kdt.team04.domain.match.review.dto.MatchRecordResponse;
+import com.kdt.team04.domain.match.review.repository.MatchRecordRepository;
+
+@Service
+public class MatchRecordGiverService {
+
+	private final MatchRecordRepository matchRecordRepository;
+
+	public MatchRecordGiverService(MatchRecordRepository matchRecordRepository) {
+		this.matchRecordRepository = matchRecordRepository;
+	}
+
+	public MatchRecordResponse.TotalCount findByTeamTotalRecord(Long id) {
+		return matchRecordRepository.getTotalCount(id);
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/service/MatchReviewGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/service/MatchReviewGiverService.java
@@ -1,0 +1,20 @@
+package com.kdt.team04.domain.match.review.service;
+
+import org.springframework.stereotype.Service;
+
+import com.kdt.team04.domain.match.review.dto.MatchReviewResponse;
+import com.kdt.team04.domain.match.review.repository.MatchReviewRepository;
+
+@Service
+public class MatchReviewGiverService {
+
+	private final MatchReviewRepository matchReviewRepository;
+
+	public MatchReviewGiverService(MatchReviewRepository matchReviewRepository) {
+		this.matchReviewRepository = matchReviewRepository;
+	}
+
+	public MatchReviewResponse.TotalCount findByTeamTotalReview(Long teamId) {
+		return matchReviewRepository.getTotalCount(teamId);
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/match/review/service/MatchReviewGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/match/review/service/MatchReviewGiverService.java
@@ -15,6 +15,6 @@ public class MatchReviewGiverService {
 	}
 
 	public MatchReviewResponse.TotalCount findByTeamTotalReview(Long teamId) {
-		return matchReviewRepository.getTotalCount(teamId);
+		return matchReviewRepository.getTeamTotalCount(teamId);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
@@ -30,12 +30,10 @@ public class TeamController {
 
 	@Operation(summary = "팀을 생성한다.", description = "새로운 팀을 생성할 수 있습니다.")
 	@PostMapping
-	public ApiResponse<TeamResponse> create(@AuthenticationPrincipal JwtAuthentication jwtAuthentication,
+	public void create(@AuthenticationPrincipal JwtAuthentication jwtAuthentication,
 		@RequestBody TeamRequest.CreateRequest request) {
-		TeamResponse team = teamService.create(jwtAuthentication.id(), request.name(), request.sportsCategory(),
+		teamService.create(jwtAuthentication.id(), request.name(), request.sportsCategory(),
 			request.description());
-
-		return new ApiResponse<>(team);
 	}
 
 	@Operation(summary = "팀 프로필 조회", description = "해당 id의 팀 프로필을 조회할 수 있습니다.")

--- a/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kdt.team04.common.ApiResponse;
+import com.kdt.team04.common.exception.NotAuthenticationException;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.team.dto.TeamRequest;
 import com.kdt.team04.domain.team.dto.TeamResponse;
@@ -32,6 +33,11 @@ public class TeamController {
 	@PostMapping
 	public void create(@AuthenticationPrincipal JwtAuthentication jwtAuthentication,
 		@RequestBody TeamRequest.CreateRequest request) {
+
+		if (jwtAuthentication == null) {
+			throw new NotAuthenticationException("Not Authenticated");
+		}
+
 		teamService.create(jwtAuthentication.id(), request.name(), request.sportsCategory(),
 			request.description());
 	}
@@ -43,5 +49,4 @@ public class TeamController {
 
 		return new ApiResponse<>(team);
 	}
-
 }

--- a/src/main/java/com/kdt/team04/domain/team/dto/TeamConverter.java
+++ b/src/main/java/com/kdt/team04/domain/team/dto/TeamConverter.java
@@ -14,34 +14,26 @@ import com.kdt.team04.domain.user.entity.User;
 @Component
 public class TeamConverter {
 
-	public User toUser(UserResponse userResponse) {
-		return new User(userResponse.id(), userResponse.password(), userResponse.username(), userResponse.nickname());
-	}
-
-	public UserResponse toUserResponse(User user) {
-		return new UserResponse(user.getId(), user.getUsername(), user.getPassword(), user.getNickname());
-	}
-
-	public Team toTeam(TeamResponse response) {
+	public Team toTeam(TeamResponse response, User leader) {
 		return Team.builder()
 			.id(response.id())
 			.name(response.teamName())
 			.description(response.description())
-			.leader(toUser(response.leader()))
+			.leader(leader)
 			.build();
 	}
 
-	public TeamResponse toTeamResponse(Team team) {
+	public TeamResponse toTeamResponse(Team team, UserResponse leader) {
 		return TeamResponse.builder()
 			.id(team.getId())
 			.teamName(team.getName())
 			.sportsCategory(team.getSportsCategory())
 			.description(team.getDescription())
-			.leader(toUserResponse(team.getLeader()))
+			.leader(leader)
 			.build();
 	}
 
-	public TeamResponse toTeamResponse(Team team, List<TeamMemberResponse> teamMemberResponses,
+	public TeamResponse toTeamResponse(Team team, UserResponse leader, List<TeamMemberResponse> teamMemberResponses,
 		MatchRecordResponse.TotalCount recordCount, MatchReviewResponse.TotalCount review) {
 		return TeamResponse.builder()
 			.id(team.getId())
@@ -51,7 +43,7 @@ public class TeamConverter {
 			.description(team.getDescription())
 			.matchRecord(recordCount)
 			.matchReview(review)
-			.leader(toUserResponse(team.getLeader()))
+			.leader(leader)
 			.build();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/dto/TeamConverter.java
+++ b/src/main/java/com/kdt/team04/domain/team/dto/TeamConverter.java
@@ -4,23 +4,22 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.kdt.team04.domain.match.review.dto.MatchRecordResponse;
+import com.kdt.team04.domain.match.review.dto.MatchReviewResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.teammember.dto.TeamMemberResponse;
-import com.kdt.team04.domain.user.UserConverter;
 import com.kdt.team04.domain.user.dto.UserResponse;
 import com.kdt.team04.domain.user.entity.User;
 
 @Component
 public class TeamConverter {
 
-	private final UserConverter userConverter;
-
-	public TeamConverter(UserConverter userConverter) {
-		this.userConverter = userConverter;
-	}
-
 	public User toUser(UserResponse userResponse) {
 		return new User(userResponse.id(), userResponse.password(), userResponse.username(), userResponse.nickname());
+	}
+
+	public UserResponse toUserResponse(User user) {
+		return new UserResponse(user.getId(), user.getUsername(), user.getPassword(), user.getNickname());
 	}
 
 	public Team toTeam(TeamResponse response) {
@@ -28,7 +27,7 @@ public class TeamConverter {
 			.id(response.id())
 			.name(response.teamName())
 			.description(response.description())
-			.leader(userConverter.toUser(response.leader()))
+			.leader(toUser(response.leader()))
 			.build();
 	}
 
@@ -38,18 +37,21 @@ public class TeamConverter {
 			.teamName(team.getName())
 			.sportsCategory(team.getSportsCategory())
 			.description(team.getDescription())
-			.leader(userConverter.toUserResponse(team.getLeader()))
+			.leader(toUserResponse(team.getLeader()))
 			.build();
 	}
 
-	public TeamResponse toTeamResponse(Team team, List<TeamMemberResponse> teamMemberResponses) {
+	public TeamResponse toTeamResponse(Team team, List<TeamMemberResponse> teamMemberResponses,
+		MatchRecordResponse.TotalCount recordCount, MatchReviewResponse.TotalCount review) {
 		return TeamResponse.builder()
 			.id(team.getId())
 			.teamName(team.getName())
 			.members(teamMemberResponses)
 			.sportsCategory(team.getSportsCategory())
 			.description(team.getDescription())
-			.leader(userConverter.toUserResponse(team.getLeader()))
+			.matchRecord(recordCount)
+			.matchReview(review)
+			.leader(toUserResponse(team.getLeader()))
 			.build();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/dto/TeamResponse.java
+++ b/src/main/java/com/kdt/team04/domain/team/dto/TeamResponse.java
@@ -2,6 +2,8 @@ package com.kdt.team04.domain.team.dto;
 
 import java.util.List;
 
+import com.kdt.team04.domain.match.review.dto.MatchRecordResponse;
+import com.kdt.team04.domain.match.review.dto.MatchReviewResponse;
 import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.teammember.dto.TeamMemberResponse;
 import com.kdt.team04.domain.user.dto.UserResponse;
@@ -13,8 +15,10 @@ public record TeamResponse(
 	Long id,
 	String teamName,
 	String description,
-	List<TeamMemberResponse> members,
 	SportsCategory sportsCategory,
+	List<TeamMemberResponse> members,
+	MatchRecordResponse.TotalCount matchRecord,
+	MatchReviewResponse.TotalCount matchReview,
 	UserResponse leader
 ) {
 }

--- a/src/main/java/com/kdt/team04/domain/team/entity/Team.java
+++ b/src/main/java/com/kdt/team04/domain/team/entity/Team.java
@@ -37,6 +37,10 @@ public class Team extends BaseEntity {
 	protected Team() {
 	}
 
+	public Team(String name, String description, SportsCategory sportsCategory, User leader) {
+		this(null, name, description, sportsCategory, leader);
+	}
+
 	@Builder
 	public Team(Long id, String name, String description, SportsCategory sportsCategory, User leader) {
 		this.id = id;

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
@@ -12,6 +12,7 @@ import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.team.repository.TeamRepository;
 import com.kdt.team04.domain.user.UserConverter;
+import com.kdt.team04.domain.user.dto.UserResponse;
 
 @Service
 @Transactional(readOnly = true)
@@ -31,8 +32,9 @@ public class TeamGiverService {
 		Team team = teamRepository.findById(id)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.TEAM_NOT_FOUND,
 				MessageFormat.format("TeamId = {0}", id)));
+		UserResponse leader = userConverter.toUserResponse(team.getLeader());
 
-		return teamConverter.toTeamResponse(team, userConverter.toUserResponse(team.getLeader()));
+		return teamConverter.toTeamResponse(team, leader);
 	}
 
 }

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
@@ -11,6 +11,7 @@ import com.kdt.team04.domain.team.dto.TeamConverter;
 import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.team.repository.TeamRepository;
+import com.kdt.team04.domain.user.UserConverter;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,10 +19,12 @@ public class TeamGiverService {
 
 	private final TeamRepository teamRepository;
 	private final TeamConverter teamConverter;
+	private final UserConverter userConverter;
 
-	public TeamGiverService(TeamRepository teamRepository, TeamConverter teamConverter) {
+	public TeamGiverService(TeamRepository teamRepository, TeamConverter teamConverter, UserConverter userConverter) {
 		this.teamRepository = teamRepository;
 		this.teamConverter = teamConverter;
+		this.userConverter = userConverter;
 	}
 
 	public TeamResponse findById(Long id) {
@@ -29,7 +32,7 @@ public class TeamGiverService {
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.TEAM_NOT_FOUND,
 				MessageFormat.format("TeamId = {0}", id)));
 
-		return teamConverter.toTeamResponse(team);
+		return teamConverter.toTeamResponse(team, userConverter.toUserResponse(team.getLeader()));
 	}
 
 }

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
@@ -19,6 +19,8 @@ import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.team.repository.TeamRepository;
 import com.kdt.team04.domain.teammember.dto.TeamMemberResponse;
 import com.kdt.team04.domain.teammember.service.TeamMemberGiverService;
+import com.kdt.team04.domain.user.UserConverter;
+import com.kdt.team04.domain.user.dto.UserResponse;
 import com.kdt.team04.domain.user.entity.User;
 import com.kdt.team04.domain.user.service.UserService;
 
@@ -28,16 +30,19 @@ public class TeamService {
 
 	private final TeamRepository teamRepository;
 	private final TeamConverter teamConverter;
+	private final UserConverter userConverter;
 	private final UserService userService;
 	private final TeamMemberGiverService teamMemberGiver;
 	private final MatchRecordGiverService matchRecordGiver;
 	private final MatchReviewGiverService matchReviewGiver;
 
-	public TeamService(TeamRepository teamRepository, TeamConverter teamConverter, UserService userService,
+	public TeamService(TeamRepository teamRepository, TeamConverter teamConverter, UserConverter userConverter,
+		UserService userService,
 		TeamMemberGiverService teamMemberGiver, MatchRecordGiverService matchRecordGiver,
 		MatchReviewGiverService matchReviewGiver) {
 		this.teamRepository = teamRepository;
 		this.teamConverter = teamConverter;
+		this.userConverter = userConverter;
 		this.userService = userService;
 		this.teamMemberGiver = teamMemberGiver;
 		this.matchRecordGiver = matchRecordGiver;
@@ -46,7 +51,7 @@ public class TeamService {
 
 	@Transactional
 	public Long create(Long userId, String teamName, SportsCategory sportsCategory, String description) {
-		User user = teamConverter.toUser(userService.findById(userId));
+		User user = userConverter.toUser(userService.findById(userId));
 		Team savedTeam = teamRepository.save(
 			Team.builder()
 				.name(teamName)
@@ -66,7 +71,12 @@ public class TeamService {
 		List<TeamMemberResponse> teamMemberResponses = teamMemberGiver.findAllByTeamId(id);
 		MatchRecordResponse.TotalCount totalRecord = matchRecordGiver.findByTeamTotalRecord(id);
 		MatchReviewResponse.TotalCount totalReview = matchReviewGiver.findByTeamTotalReview(id);
+		UserResponse leader = userConverter.toUserResponse(team.getLeader());
 
-		return teamConverter.toTeamResponse(team, teamMemberResponses, totalRecord, totalReview);
+		return teamConverter.toTeamResponse(team, leader, teamMemberResponses, totalRecord, totalReview);
+	}
+
+	public void test(Long id) {
+		matchReviewGiver.findByTeamTotalReview(id);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationService.java
+++ b/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationService.java
@@ -53,7 +53,7 @@ public class TeamInvitationService {
 
 		TeamResponse teamResponse = teamService.findById(teamId);
 		UserResponse targetResponse = userService.findById(targetUserId);
-		Team team = teamConverter.toTeam(teamResponse);
+		Team team = teamConverter.toTeam(teamResponse, userConverter.toUser(teamResponse.leader()));
 
 		if (!Objects.equals(team.getLeader().getId(), myId)) {
 			throw new BusinessException(ErrorCode.NOT_TEAM_LEADER,

--- a/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationService.java
+++ b/src/main/java/com/kdt/team04/domain/teaminvitation/service/TeamInvitationService.java
@@ -17,7 +17,6 @@ import com.kdt.team04.domain.teaminvitation.entity.InvitationStatus;
 import com.kdt.team04.domain.teaminvitation.entity.TeamInvitation;
 import com.kdt.team04.domain.teaminvitation.repository.TeamInvitationRepository;
 import com.kdt.team04.domain.teammember.service.TeamMemberGiverService;
-import com.kdt.team04.domain.teammember.service.TeamMemberService;
 import com.kdt.team04.domain.user.UserConverter;
 import com.kdt.team04.domain.user.dto.UserResponse;
 import com.kdt.team04.domain.user.entity.User;
@@ -60,6 +59,7 @@ public class TeamInvitationService {
 			throw new BusinessException(ErrorCode.NOT_TEAM_LEADER,
 				MessageFormat.format("{0} is not team leader id {1} ", myId, team.getLeader().getId()));
 		}
+
 		User target = userConverter.toUser(targetResponse);
 		TeamInvitation invitation = new TeamInvitation(team, target, InvitationStatus.WAITING);
 		Long savedInvitationId = teamInvitationRepository.save(invitation).getId();

--- a/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberConverter.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/dto/TeamMemberConverter.java
@@ -2,10 +2,8 @@ package com.kdt.team04.domain.teammember.dto;
 
 import org.springframework.stereotype.Component;
 
-import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.teammember.entity.TeamMember;
-import com.kdt.team04.domain.user.dto.UserResponse;
 import com.kdt.team04.domain.user.entity.User;
 
 @Component

--- a/src/main/resources/db/migration/V3_2__Alter_match_review_add_column.sql
+++ b/src/main/resources/db/migration/V3_2__Alter_match_review_add_column.sql
@@ -1,0 +1,9 @@
+ALTER TABLE match_review MODIFY user_id BIGINT NULL;
+
+ALTER TABLE match_review ADD team_id BIGINT NULL;
+ALTER TABLE match_review ADD target_user_id BIGINT NULL;
+ALTER TABLE match_review ADD target_team_id BIGINT NULL;
+
+ALTER TABLE match_review ADD FOREIGN KEY (team_id) REFERENCES team(id);
+ALTER TABLE match_review ADD FOREIGN KEY (target_user_id) REFERENCES users(id);
+ALTER TABLE match_review ADD FOREIGN KEY (target_team_id) REFERENCES team(id);

--- a/src/test/java/com/kdt/team04/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/team/service/TeamServiceTest.java
@@ -30,6 +30,7 @@ import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.team.repository.TeamRepository;
 import com.kdt.team04.domain.teammember.service.TeamMemberGiverService;
+import com.kdt.team04.domain.user.UserConverter;
 import com.kdt.team04.domain.user.dto.UserResponse;
 import com.kdt.team04.domain.user.entity.User;
 import com.kdt.team04.domain.user.service.UserService;
@@ -45,6 +46,9 @@ class TeamServiceTest {
 
 	@Mock
 	private TeamConverter teamConverter;
+
+	@Mock
+	private UserConverter userConverter;
 
 	@Mock
 	private TeamRepository teamRepository;
@@ -76,9 +80,8 @@ class TeamServiceTest {
 	void createSuccess() {
 		//given
 		given(userService.findById(USER.getId())).willReturn(USER_RESPONSE);
-		given(teamConverter.toUser(USER_RESPONSE)).willReturn(USER);
+		given(userConverter.toUser(USER_RESPONSE)).willReturn(USER);
 		given(teamRepository.save(any(Team.class))).willReturn(TEAM);
-
 		//when
 		Long teamId = teamService.create(USER.getId(), CREATE_REQUEST.name(),
 			CREATE_REQUEST.sportsCategory(),
@@ -86,7 +89,6 @@ class TeamServiceTest {
 
 		//then
 		verify(userService, times(1)).findById(USER.getId());
-		verify(teamConverter, times(1)).toUser(USER_RESPONSE);
 		verify(teamRepository, times(1)).save(any(Team.class));
 
 		assertThat(teamId).isEqualTo(TEAM.getId());
@@ -97,17 +99,19 @@ class TeamServiceTest {
 	void findByIdSuccess() {
 		//given
 		given(teamRepository.findById(TEAM.getId())).willReturn(Optional.of(TEAM));
-		given(teamConverter.toTeamResponse(TEAM, Collections.emptyList(), RECORD, REVIEW)).willReturn(RESPONSE);
+		given(teamConverter.toTeamResponse(TEAM, USER_RESPONSE, Collections.emptyList(), RECORD, REVIEW)).willReturn(
+			RESPONSE);
 		given(teamMemberGiver.findAllByTeamId(TEAM.getId())).willReturn(Collections.emptyList());
 		given(matchRecordGiver.findByTeamTotalRecord(TEAM.getId())).willReturn(RECORD);
 		given(matchReviewGiver.findByTeamTotalReview(TEAM.getId())).willReturn(REVIEW);
+		given(userConverter.toUserResponse(USER)).willReturn(USER_RESPONSE);
 
 		//when
 		TeamResponse foundTeam = teamService.findById(TEAM.getId());
 
 		//then
 		verify(teamRepository, times(1)).findById(TEAM.getId());
-		verify(teamConverter, times(1)).toTeamResponse(TEAM, Collections.emptyList(), RECORD, REVIEW);
+		verify(teamConverter, times(1)).toTeamResponse(TEAM, USER_RESPONSE, Collections.emptyList(), RECORD, REVIEW);
 
 		assertThat(foundTeam.id()).isEqualTo(TEAM.getId());
 	}


### PR DESCRIPTION
## ✅  작업 단위
- 팀 생성 및 팀 프로필 조회
- 팀 전적 QueryDSL (승, 무, 패)
<img width="400" alt="스크린샷 2022-07-28 09 32 08" src="https://user-images.githubusercontent.com/35947674/181395237-b8be9ff2-29c0-41a5-b5b9-b390a02ba97d.png">

- 팀 리뷰 QueryDSL (최고에요, 좋아요, 별로에요) 
![스크린샷 2022-07-28 12 02 37](https://user-images.githubusercontent.com/35947674/181411177-37c045a9-d83d-467e-9837-c6ac515f726c.png)

- match review erd 변경
![스크린샷 2022-07-28 12 24 48](https://user-images.githubusercontent.com/35947674/181413757-da35b82e-5b5d-4b96-b1d5-37f129b9ecc2.png)
- 팀 작성자, target Team, target User 추가 되었습니다 
## 🤔 고민 했던 부분
- 팀 프로필 조회를 테스트 하려면 일단 매칭 작성 부터 구현이 되어야해서 테스트는 매칭 작성 구현 후 진행하겠습니다. 

## 🔊 HELP !!
- Customized~RepositoryImpl 네이밍 추천 부탁드립니다