### PR TITLE
[DK-99] 매칭 작성자는 매칭 신청을 수락 또는 거절할 수 있다.

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/CommonRestControllerAdvice.java
+++ b/src/main/java/com/kdt/team04/common/exception/CommonRestControllerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -39,6 +40,15 @@ public class CommonRestControllerAdvice {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse<ErrorCode>> handleMethodArgumentNotValidException(
 		MethodArgumentNotValidException e) {
+		this.log.warn(e.getMessage(), e);
+		ErrorCode errorCode = ErrorCode.METHOD_ARGUMENT_NOT_VALID;
+
+		return new ResponseEntity<>(new ErrorResponse<>(errorCode), errorCode.getStatus());
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	public ResponseEntity<ErrorResponse<ErrorCode>> handleMissingServletRequestParameterException(
+		MissingServletRequestParameterException e) {
 		this.log.warn(e.getMessage(), e);
 		ErrorCode errorCode = ErrorCode.METHOD_ARGUMENT_NOT_VALID;
 

--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -43,10 +43,11 @@ public enum ErrorCode {
 	AUTHOR_NOT_MATCHED("M0005", "Author not matched", HttpStatus.BAD_REQUEST),
 
 	//MATCH_PROPOSAL
-	MATCH_PROPOSAL_NOT_FOUND("MP0001", "Not found match proposal", HttpStatus.NOT_FOUND),
+	MATCH_PROPOSAL_NOT_FOUND("MP0001", "Not found proposal", HttpStatus.NOT_FOUND),
 	INVALID_CREATE_REQUEST("MP0002", "Invalid proposal request", HttpStatus.BAD_REQUEST),
 	MATCH_PROPOSAL_NOT_APPROVED("MP0003", "The request is not approved.", HttpStatus.BAD_REQUEST),
 	ANOTHER_MATCH_PROPOSAL_ALREADY_FIXED("MP0004", "Fixed another proposal already exists.", HttpStatus.BAD_REQUEST),
+	INVALID_REACT("MP0005", "Invalid react", HttpStatus.BAD_REQUEST),
 
 	//MATCH_CHAT
 	MATCH_CHAT_NOT_CORRECT_CHAT_PARTNER("MC0002", "The chat partner is incorrect.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/kdt/team04/domain/matches/match/entity/Match.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/entity/Match.java
@@ -64,10 +64,6 @@ public class Match extends BaseEntity {
 	@Embedded
 	private Location location;
 
-	public void setLocation(Location location) {
-		this.location = location;
-	}
-
 	protected Match() {/*no-op*/}
 
 	@Builder
@@ -86,10 +82,6 @@ public class Match extends BaseEntity {
 		this.user = user;
 		this.team = team;
 		this.location = location;
-	}
-
-	public void updateStatus(MatchStatus status) {
-		this.status = status;
 	}
 
 	public Long getId() {

--- a/src/main/java/com/kdt/team04/domain/matches/match/entity/Match.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/entity/Match.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 import java.time.LocalDate;
 
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -60,7 +61,12 @@ public class Match extends BaseEntity {
 	@JoinColumn(name = "team_id")
 	private Team team;
 
+	@Embedded
 	private Location location;
+
+	public void setLocation(Location location) {
+		this.location = location;
+	}
 
 	protected Match() {/*no-op*/}
 
@@ -80,6 +86,10 @@ public class Match extends BaseEntity {
 		this.user = user;
 		this.team = team;
 		this.location = location;
+	}
+
+	public void updateStatus(MatchStatus status) {
+		this.status = status;
 	}
 
 	public Long getId() {

--- a/src/main/java/com/kdt/team04/domain/matches/match/entity/MatchStatus.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/entity/MatchStatus.java
@@ -1,5 +1,9 @@
 package com.kdt.team04.domain.matches.match.entity;
 
 public enum MatchStatus {
-	WAITING, IN_GAME, END
+	WAITING, IN_GAME, END;
+
+	public boolean isMatched() {
+		return this != MatchStatus.WAITING;
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -15,7 +15,6 @@ import com.kdt.team04.domain.matches.match.dto.MatchPagingCursor;
 import com.kdt.team04.domain.matches.match.dto.MatchRequest;
 import com.kdt.team04.domain.matches.match.dto.MatchResponse;
 import com.kdt.team04.domain.matches.match.entity.Match;
-import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
 import com.kdt.team04.domain.matches.match.repository.MatchRepository;
 import com.kdt.team04.domain.team.dto.TeamConverter;
@@ -149,12 +148,5 @@ public class MatchService {
 			throw new BusinessException(ErrorCode.NOT_TEAM_LEADER,
 				MessageFormat.format("teamId = {0} , userId = {1}", teamId, userId));
 		}
-	}
-
-	public void updateStatus(Long id, MatchStatus status) {
-		Match match = matchRepository.findById(id)
-			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MATCH_NOT_FOUND,
-				MessageFormat.format("matchId = {0}", id)));
-		match.updateStatus(status);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -16,6 +16,7 @@ import com.kdt.team04.domain.matches.match.dto.MatchPagingCursor;
 import com.kdt.team04.domain.matches.match.dto.MatchRequest;
 import com.kdt.team04.domain.matches.match.dto.MatchResponse;
 import com.kdt.team04.domain.matches.match.entity.Match;
+import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
 import com.kdt.team04.domain.matches.match.repository.MatchRepository;
 import com.kdt.team04.domain.team.SportsCategory;
@@ -122,10 +123,8 @@ public class MatchService {
 		}
 		Location location = foundUser.location();
 
-		PageDto.CursorResponse<MatchResponse.ListViewResponse, MatchPagingCursor> foundMatches = matchRepository.findByLocationPaging(
+		return matchRepository.findByLocationPaging(
 			location.getLatitude(), location.getLongitude(), request);
-
-		return foundMatches;
 	}
 
 	private Boolean hasNext(LocalDateTime createdAtCursor, Long idCursor, SportsCategory sportsCategory) {
@@ -161,5 +160,12 @@ public class MatchService {
 			throw new BusinessException(ErrorCode.NOT_TEAM_LEADER,
 				MessageFormat.format("teamId = {0} , userId = {1}", teamId, userId));
 		}
+	}
+
+	public void updateStatus(Long id, MatchStatus status) {
+		Match match = matchRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MATCH_NOT_FOUND,
+				MessageFormat.format("matchId = {0}", id)));
+		match.updateStatus(status);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
@@ -8,13 +8,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kdt.team04.common.exception.NotAuthenticationException;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalRequest;
-import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.kdt.team04.domain.matches.proposal.service.MatchProposalService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,7 +41,7 @@ public class MatchProposalController {
 	@PatchMapping("/{id}")
 	@Operation(summary = "신청 수락 및 거절", description = "대결 공고자는 대결 신청을 수락 또는 거절 할 수 있다.")
 	public void proposeReact(@PathVariable Long matchId, @PathVariable Long id,
-		@RequestParam MatchProposalStatus status) {
-		matchProposalService.react(matchId, id, status);
+		@RequestBody @Valid MatchProposalRequest.ProposalReact request) {
+		matchProposalService.react(matchId, id, request.status());
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
@@ -3,15 +3,18 @@ package com.kdt.team04.domain.matches.proposal.controller;
 import javax.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kdt.team04.common.exception.NotAuthenticationException;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalRequest;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.kdt.team04.domain.matches.proposal.service.MatchProposalService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,5 +38,12 @@ public class MatchProposalController {
 		}
 
 		matchProposalService.create(jwtAuthentication.id(), matchId, request);
+	}
+
+	@PatchMapping("/{id}")
+	@Operation(summary = "신청 수락 및 거절", description = "대결 공고자는 대결 신청을 수락 또는 거절 할 수 있다.")
+	public void proposeReact(@PathVariable Long matchId, @PathVariable Long id,
+		@RequestParam MatchProposalStatus status) {
+		matchProposalService.react(matchId, id, status);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalRequest.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalRequest.java
@@ -1,7 +1,10 @@
 package com.kdt.team04.domain.matches.proposal.dto;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -16,4 +19,6 @@ public record MatchProposalRequest() {
 		String content
 	) {
 	}
+
+	public record ProposalReact(@NotNull MatchProposalStatus status) {}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/entity/MatchProposal.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/entity/MatchProposal.java
@@ -59,6 +59,10 @@ public class MatchProposal extends BaseEntity {
 		this.status = defaultIfNull(status, WAITING);
 	}
 
+	public void updateStatus(MatchProposalStatus status) {
+		this.status = status;
+	}
+
 	public Long getId() {
 		return id;
 	}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/entity/MatchProposalStatus.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/entity/MatchProposalStatus.java
@@ -1,5 +1,9 @@
 package com.kdt.team04.domain.matches.proposal.entity;
 
 public enum MatchProposalStatus {
-	WAITING, APPROVED, REFUSE, FIXED
+	WAITING, APPROVED, REFUSE, FIXED;
+
+	public boolean isApproved() {
+		return this == MatchProposalStatus.APPROVED;
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/user/entity/User.java
+++ b/src/main/java/com/kdt/team04/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.kdt.team04.domain.user.entity;
 
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -37,6 +38,7 @@ public class User extends BaseEntity {
 	@Column(unique = true)
 	private String nickname;
 
+	@Embedded
 	private Location location;
 
 	protected User() {

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
@@ -155,45 +155,6 @@ class MatchProposalServiceIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("매칭 작성자가 매칭 신청을 수락하면 신청 상태는 APPROVE, 매칭 상태는 IN_GAME으로 변경된다.")
-	void testApproveReactSuccess() {
-		//given
-		User author = new User("author", "author", "aA1234!");
-		User proposer = new User("proposer", "proposer", "aA1234!");
-		entityManager.persist(author);
-		entityManager.persist(proposer);
-
-		Match match = Match.builder()
-			.title("match")
-			.status(MatchStatus.WAITING)
-			.matchDate(LocalDate.now())
-			.matchType(MatchType.INDIVIDUAL_MATCH)
-			.participants(1)
-			.user(author)
-			.sportsCategory(SportsCategory.BADMINTON)
-			.content("content")
-			.build();
-		entityManager.persist(match);
-		MatchProposal proposal = MatchProposal.builder()
-			.user(proposer)
-			.team(null)
-			.match(match)
-			.content("content")
-			.status(MatchProposalStatus.WAITING)
-			.build();
-		MatchProposal savedProposal = matchProposalRepository.save(proposal);
-
-		//when
-		MatchProposalStatus react = matchProposalService.react(match.getId(), savedProposal.getId(),
-			MatchProposalStatus.APPROVED);
-
-		//then
-		assertThat(react).isEqualTo(MatchProposalStatus.APPROVED);
-		assertThat(match.getStatus()).isEqualTo(MatchStatus.IN_GAME);
-
-	}
-
-	@Test
 	@DisplayName("매칭 작성자가 매칭 신청을 거절하면 신청 상태가 REFUSE로 변경된다.")
 	void testRefuseReactSuccess() {
 		//given

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
@@ -18,6 +18,9 @@ import com.kdt.team04.domain.matches.match.entity.Match;
 import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalRequest;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
+import com.kdt.team04.domain.matches.proposal.repository.MatchProposalRepository;
 import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.user.entity.User;
@@ -31,6 +34,9 @@ class MatchProposalServiceIntegrationTest {
 
 	@Autowired
 	private MatchProposalService matchProposalService;
+
+	@Autowired
+	private MatchProposalRepository matchProposalRepository;
 
 	@Test
 	@DisplayName("개인전 매칭을 신청하고 해당 신청 생성 후 Id 값을 return 한다.")
@@ -146,5 +152,118 @@ class MatchProposalServiceIntegrationTest {
 		//when, then
 		assertThatThrownBy(() -> matchProposalService.create(proposer.getId(), match.getId(), request))
 			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	@DisplayName("매칭 작성자가 매칭 신청을 수락하면 신청 상태는 APPROVE, 매칭 상태는 IN_GAME으로 변경된다.")
+	void testApproveReactSuccess() {
+		//given
+		User author = new User("author", "author", "aA1234!");
+		User proposer = new User("proposer", "proposer", "aA1234!");
+		entityManager.persist(author);
+		entityManager.persist(proposer);
+
+		Match match = Match.builder()
+			.title("match")
+			.status(MatchStatus.WAITING)
+			.matchDate(LocalDate.now())
+			.matchType(MatchType.INDIVIDUAL_MATCH)
+			.participants(1)
+			.user(author)
+			.sportsCategory(SportsCategory.BADMINTON)
+			.content("content")
+			.build();
+		entityManager.persist(match);
+		MatchProposal proposal = MatchProposal.builder()
+			.user(proposer)
+			.team(null)
+			.match(match)
+			.content("content")
+			.status(MatchProposalStatus.WAITING)
+			.build();
+		MatchProposal savedProposal = matchProposalRepository.save(proposal);
+
+		//when
+		MatchProposalStatus react = matchProposalService.react(match.getId(), savedProposal.getId(),
+			MatchProposalStatus.APPROVED);
+
+		//then
+		assertThat(react).isEqualTo(MatchProposalStatus.APPROVED);
+		assertThat(match.getStatus()).isEqualTo(MatchStatus.IN_GAME);
+
+	}
+
+	@Test
+	@DisplayName("매칭 작성자가 매칭 신청을 거절하면 신청 상태가 REFUSE로 변경된다.")
+	void testRefuseReactSuccess() {
+		//given
+		User author = new User("author", "author", "aA1234!");
+		User proposer = new User("proposer", "proposer", "aA1234!");
+		entityManager.persist(author);
+		entityManager.persist(proposer);
+
+		Match match = Match.builder()
+			.title("match")
+			.status(MatchStatus.WAITING)
+			.matchDate(LocalDate.now())
+			.matchType(MatchType.INDIVIDUAL_MATCH)
+			.participants(1)
+			.user(author)
+			.sportsCategory(SportsCategory.BADMINTON)
+			.content("content")
+			.build();
+		entityManager.persist(match);
+		MatchProposal proposal = MatchProposal.builder()
+			.user(proposer)
+			.team(null)
+			.match(match)
+			.content("content")
+			.status(MatchProposalStatus.WAITING)
+			.build();
+		MatchProposal savedProposal = matchProposalRepository.save(proposal);
+
+		//when
+		MatchProposalStatus react = matchProposalService.react(match.getId(), savedProposal.getId(),
+			MatchProposalStatus.REFUSE);
+
+		//then
+		assertThat(react).isEqualTo(MatchProposalStatus.REFUSE);
+		assertThat(match.getStatus()).isEqualTo(MatchStatus.WAITING);
+
+	}
+
+	@Test
+	@DisplayName("매칭이 이루어진 후 다른 신청을 수락하면 예외가 발생한다.")
+	void testAlreadyMatchedApproveReactFail() {
+		//given
+		User author = new User("author", "author", "aA1234!");
+		User proposer = new User("proposer", "proposer", "aA1234!");
+		entityManager.persist(author);
+		entityManager.persist(proposer);
+
+		Match match = Match.builder()
+			.title("match")
+			.status(MatchStatus.IN_GAME)
+			.matchDate(LocalDate.now())
+			.matchType(MatchType.INDIVIDUAL_MATCH)
+			.participants(1)
+			.user(author)
+			.sportsCategory(SportsCategory.BADMINTON)
+			.content("content")
+			.build();
+		entityManager.persist(match);
+		MatchProposal proposal = MatchProposal.builder()
+			.user(proposer)
+			.team(null)
+			.match(match)
+			.content("content")
+			.status(MatchProposalStatus.WAITING)
+			.build();
+		MatchProposal savedProposal = matchProposalRepository.save(proposal);
+
+		//when
+		assertThatThrownBy(() -> matchProposalService.react(match.getId(), savedProposal.getId(),
+			MatchProposalStatus.APPROVED)).isInstanceOf(BusinessException.class);
+
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위

- 매칭 신청 및 거절 기능 구현
   - 일단 기존의 API 처럼 구현했습니다. (거절 시 삭제에 대한 내용없이!) 
<img width="600" alt="image" src="https://user-images.githubusercontent.com/35947674/181907810-e331e7ba-7f6f-4a5c-8ad2-5f558c89a7f0.png">

- common advice에 해당 예외 추가했습니다.
    - @RequestParam이 null일 경우 발생하는 예외입니다.
    - 에러 코드 valid로 사용했습니다.
- 이미 매칭이 성사된 매칭의 다른 신청을 수락할 시 예외가 터지도록 했습니다.

## 🤔 고민 했던 부분
- react 네이밍 괜찮은가요 ? 수락이나 거절을 반응으로 생각해서 해당 네이밍을 사용했습니다.

## 🔊 HELP !!