### PR TITLE
[Dk-311]행정구역 조회 OpenAPI 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ configurations {
 	}
 }
 
+
+ext {
+	set('springCloudVersion', "2021.0.3")
+}
+
 jar {
 	enabled = false
 }
@@ -81,6 +86,15 @@ dependencies {
 
 	// ANNOTATION PROCESSOR
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+	//FEIGN CLIENT
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('compileJava') {

--- a/src/main/java/com/kdt/team04/Application.java
+++ b/src/main/java/com/kdt/team04/Application.java
@@ -2,8 +2,10 @@ package com.kdt.team04;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kdt/team04/common/config/DivisionApiProperties.java
+++ b/src/main/java/com/kdt/team04/common/config/DivisionApiProperties.java
@@ -1,0 +1,10 @@
+package com.kdt.team04.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "division")
+public record DivisionApiProperties(String key, String domain) {
+
+}

--- a/src/main/java/com/kdt/team04/common/config/WebMvcConfig.java
+++ b/src/main/java/com/kdt/team04/common/config/WebMvcConfig.java
@@ -6,7 +6,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@EnableConfigurationProperties({CorsConfigProperties.class})
+@EnableConfigurationProperties({CorsConfigProperties.class, DivisionApiProperties.class})
 public class WebMvcConfig implements WebMvcConfigurer {
 
 	private final CorsConfigProperties corsConfigProperties;

--- a/src/main/java/com/kdt/team04/domain/matches/match/repository/MatchRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/repository/MatchRepository.java
@@ -1,13 +1,8 @@
 package com.kdt.team04.domain.matches.match.repository;
 
-import java.time.LocalDateTime;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kdt.team04.domain.matches.match.entity.Match;
-import com.kdt.team04.domain.team.SportsCategory;
 
-public interface MatchRepository extends JpaRepository<Match, Long> ,CustomizedMatchRepository {
-	Boolean existsByCreatedAtLessThanEqualAndIdLessThanAndSportsCategory(LocalDateTime cursorCreatedAt, Long cursorId,
-		SportsCategory sportsCategory);
+public interface MatchRepository extends JpaRepository<Match, Long>, CustomizedMatchRepository {
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -1,7 +1,6 @@
 package com.kdt.team04.domain.matches.match.service;
 
 import java.text.MessageFormat;
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.springframework.stereotype.Service;
@@ -18,7 +17,6 @@ import com.kdt.team04.domain.matches.match.dto.MatchResponse;
 import com.kdt.team04.domain.matches.match.entity.Match;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
 import com.kdt.team04.domain.matches.match.repository.MatchRepository;
-import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.team.dto.TeamConverter;
 import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
@@ -126,15 +124,6 @@ public class MatchService {
 			location.getLatitude(), location.getLongitude(), request);
 
 		return foundMatches;
-	}
-
-	private Boolean hasNext(LocalDateTime createdAtCursor, Long idCursor, SportsCategory sportsCategory) {
-		if (createdAtCursor == null || idCursor == null) {
-			return false;
-		}
-
-		return this.matchRepository.existsByCreatedAtLessThanEqualAndIdLessThanAndSportsCategory(createdAtCursor,
-			idCursor, sportsCategory);
 	}
 
 	public MatchResponse findById(Long id) {

--- a/src/main/java/com/kdt/team04/feign/division/client/DivisionApiClient.java
+++ b/src/main/java/com/kdt/team04/feign/division/client/DivisionApiClient.java
@@ -1,0 +1,16 @@
+package com.kdt.team04.feign.division.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.kdt.team04.feign.division.dto.DivisionApiResponse;
+
+@FeignClient(name = "division", url = "https://api.vworld.kr/req/data")
+public interface DivisionApiClient {
+
+	@GetMapping("?request=getfeature&size=1000&page=1&geometry=false&attribute=true&crs=EPSG:3857")
+	DivisionApiResponse getDivisions(@RequestParam String domain, @RequestParam String key, @RequestParam String data,
+		@RequestParam(required = false) String attrfilter, @RequestParam String geomfilter);
+
+}

--- a/src/main/java/com/kdt/team04/feign/division/controller/DivisionApiController.java
+++ b/src/main/java/com/kdt/team04/feign/division/controller/DivisionApiController.java
@@ -21,7 +21,6 @@ public class DivisionApiController {
 
 	@GetMapping("/api/divisions")
 	public ApiResponse<List<DivisionApiResponse.Feature>> getDivisions(DivisionRequest divisionRequest) {
-		System.out.println(divisionRequest);
 		return new ApiResponse<>(divisionService.getDivisions(divisionRequest)
 			.response()
 			.result()

--- a/src/main/java/com/kdt/team04/feign/division/controller/DivisionApiController.java
+++ b/src/main/java/com/kdt/team04/feign/division/controller/DivisionApiController.java
@@ -1,0 +1,31 @@
+package com.kdt.team04.feign.division.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kdt.team04.common.ApiResponse;
+import com.kdt.team04.feign.division.dto.DivisionApiResponse;
+import com.kdt.team04.feign.division.dto.DivisionRequest;
+import com.kdt.team04.feign.division.service.DivisionService;
+
+@RestController
+public class DivisionApiController {
+
+	private final DivisionService divisionService;
+
+	public DivisionApiController(DivisionService divisionService) {
+		this.divisionService = divisionService;
+	}
+
+	@GetMapping("/api/divisions")
+	public ApiResponse<List<DivisionApiResponse.Feature>> getDivisions(DivisionRequest divisionRequest) {
+		System.out.println(divisionRequest);
+		return new ApiResponse<>(divisionService.getDivisions(divisionRequest)
+			.response()
+			.result()
+			.featureCollection()
+			.features());
+	}
+}

--- a/src/main/java/com/kdt/team04/feign/division/dto/DivisionApiResponse.java
+++ b/src/main/java/com/kdt/team04/feign/division/dto/DivisionApiResponse.java
@@ -1,0 +1,33 @@
+package com.kdt.team04.feign.division.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record DivisionApiResponse(Response response) {
+
+	public record Response(Result result) {
+
+	}
+
+	public record Result(FeatureCollection featureCollection) {
+	}
+
+	public record FeatureCollection(String type, List<Feature> features) {
+
+	}
+
+	public record Feature(Properties properties) {
+
+	}
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	public record Properties(
+		String sig_cd,
+		String full_nm,
+		String sig_kor_nm,
+		String ctprvn_cd,
+		String ctp_kor_nm
+	) {
+	}
+}

--- a/src/main/java/com/kdt/team04/feign/division/dto/DivisionRequest.java
+++ b/src/main/java/com/kdt/team04/feign/division/dto/DivisionRequest.java
@@ -1,0 +1,5 @@
+package com.kdt.team04.feign.division.dto;
+
+public record DivisionRequest(String geomfilter, String attrfilter, String data) {
+
+}

--- a/src/main/java/com/kdt/team04/feign/division/service/DivisionService.java
+++ b/src/main/java/com/kdt/team04/feign/division/service/DivisionService.java
@@ -1,0 +1,24 @@
+package com.kdt.team04.feign.division.service;
+
+import org.springframework.stereotype.Service;
+
+import com.kdt.team04.common.config.DivisionApiProperties;
+import com.kdt.team04.feign.division.client.DivisionApiClient;
+import com.kdt.team04.feign.division.dto.DivisionApiResponse;
+import com.kdt.team04.feign.division.dto.DivisionRequest;
+
+@Service
+public class DivisionService {
+
+	private final DivisionApiClient divisionApiClient;
+	private final DivisionApiProperties divisionApiProperties;
+
+	public DivisionService(DivisionApiClient divisionApiClient, DivisionApiProperties divisionApiProperties) {
+		this.divisionApiClient = divisionApiClient;
+		this.divisionApiProperties = divisionApiProperties;
+	}
+
+	public DivisionApiResponse getDivisions(DivisionRequest request) {
+		return divisionApiClient.getDivisions(divisionApiProperties.domain(), divisionApiProperties.key(), request.data(), request.attrfilter(), request.geomfilter());
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,7 +23,6 @@ security:
         - /v3/api-docs/**
         - /swagger-ui/**
         - /swagger-ui.html/**
-        - /**
       POST:
         - /api/users/signin
         - /api/users/signup
@@ -31,7 +30,7 @@ security:
       PUT: [ ]
       DELETE: [ ]
     permit-all:
-      GET: ["/**"]
+      GET: [ ]
       POST: [ ]
       PATCH: [ ]
       PUT: [ ]

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,7 @@ security:
         - /v3/api-docs/**
         - /swagger-ui/**
         - /swagger-ui.html/**
+        - /**
       POST:
         - /api/users/signin
         - /api/users/signup
@@ -29,7 +30,7 @@ security:
       PUT: [ ]
       DELETE: [ ]
     permit-all:
-      GET: [ ]
+      GET: ["/**"]
       POST: [ ]
       PATCH: [ ]
       PUT: [ ]
@@ -44,3 +45,12 @@ jwt:
   refreshToken:
     header: rtoken
     expiry-seconds: 120
+feign:
+  client:
+    config:
+      default:
+        loggerLevel: basic
+
+division:
+  key: ${DIVISION_KEY:CEB52025-E065-364C-9DBA-44880E3B02B8}
+  domain: ${DIVISION_DOMAIN:http://localhost:8080}


### PR DESCRIPTION
## ✅  작업 단위

- [feat : 행정 구역 조회 API 구현](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/3d0d23a5134d918e56df818636bbd28625ac8a83)

저희 프로젝트에서 필요한 시, 구 데이터를 Feign Client를 이용해서 조금 더 컴팩트하고 간단하게 불러오고자 했습니다.

기존의 OpenAPI를 직접사용하면
https://api.vworld.kr/req/data?key=CEB52025-E065-364C-9DBA-44880E3B02B8&domain=http://localhost:8080&service=data&version=2.0&request=getfeature&format=json&size=1000&page=1&geometry=false&attribute=true&crs=EPSG:3857&geomfilter=BOX(13663271.680031825,3894007.9689600193,14817776.555251127,4688953.0631258525)&data=LT_C_ADSIGG_INFO&attrfilter=sig_cd:like:11
같은 긴 URL과

![image](https://user-images.githubusercontent.com/62292492/181933842-8dcc7019-7718-4cdd-b171-62dda677f410.png)

그림과 같은 불필요해보이는 데이터들을 아래와 같이 걸러냈습니다

![image](https://user-images.githubusercontent.com/62292492/181933889-84e12bc8-299c-44b3-b031-9a995b9f0e9e.png)

요청 url도 비교적 짧아졌습니다
-> http://127.0.0.1:8080/api/divisions?geomfilter=BOX(13663271.680031825,3894007.9689600193,14817776.555251127,4688953.0631258525)&data=LT_C_ADSIGG_INFO&attrfilter=sig_cd:like:11



## 🤔 고민 했던 부분

- 처음 안건데 url 최대 길이 제한이 있네요.. 너무길면 짤립니다..!

## 🔊 HELP !!

