### PR TITLE
[DK-280] 매칭 신청 목록 조회(By 매칭 ID) 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 	//JASYPT
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
 
+	//QLRM
+	implementation 'org.qlrm:qlrm:3.0.4'
+
 	// ANNOTATION PROCESSOR
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }

--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
 	MATCH_PARTICIPANTS("M0003", "Invalid match participants", HttpStatus.BAD_REQUEST),
 	INVALID_PARTICIPANTS("M0004", "Invalid match participants", HttpStatus.BAD_REQUEST),
 	AUTHOR_NOT_MATCHED("M0005", "Author not matched", HttpStatus.BAD_REQUEST),
+	MATCH_ACCESS_DENIED("M0006", "Don't have permission to access match", HttpStatus.FORBIDDEN),
 
 	//MATCH_PROPOSAL
 	MATCH_PROPOSAL_NOT_FOUND("MP0001", "Not found match proposal", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchResponse.java
@@ -45,6 +45,11 @@ public record MatchResponse(
 	String content
 ) {
 
+	public record MatchAuthorResponse(
+		Long id,
+		UserResponse.AuthorResponse author
+	) {}
+
 	public record ListViewResponse(
 		@Schema(description = "매칭 ID")
 		Long id,

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -156,6 +156,20 @@ public class MatchService {
 		return matchConverter.toMatchResponse(foundMatch, authorResponse);
 	}
 
+	public MatchResponse.MatchAuthorResponse findMatchAuthorById(Long id) {
+		Match foundMatch = matchRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MATCH_NOT_FOUND,
+				MessageFormat.format("matchId = {0}", id)));
+
+		UserResponse author = userService.findById(foundMatch.getUser().getId());
+		UserResponse.AuthorResponse authorResponse = new UserResponse.AuthorResponse(author.id(), author.nickname());
+
+		return new MatchResponse.MatchAuthorResponse(
+			foundMatch.getId(),
+			authorResponse
+		);
+	}
+
 	private void verifyLeader(Long userId, Long teamId, Long leaderId) {
 		if (!Objects.equals(userId, leaderId)) {
 			throw new BusinessException(ErrorCode.NOT_TEAM_LEADER,

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
@@ -44,8 +44,18 @@ public class MatchProposalController {
 
 	@GetMapping
 	@Operation(summary = "신청 목록 조회", description = "해당 대결의 신청 목록이 조회된다.")
-	public ApiResponse<List<MatchProposalResponse.Chat>> findAllChats(@PathVariable Long matchId) {
-		List<MatchProposalResponse.Chat> proposals = matchProposalService.findAllProposals(matchId);
+	public ApiResponse<List<MatchProposalResponse.Chat>> findAllChats(
+		@AuthenticationPrincipal JwtAuthentication jwtAuthentication,
+		@PathVariable Long matchId
+	) {
+		if (jwtAuthentication == null) {
+			throw new NotAuthenticationException("Not Authenticated");
+		}
+
+		List<MatchProposalResponse.Chat> proposals = matchProposalService.findAllProposals(
+			matchId,
+			jwtAuthentication.id()
+		);
 
 		return new ApiResponse<>(proposals);
 	}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
@@ -1,17 +1,22 @@
 package com.kdt.team04.domain.matches.proposal.controller;
 
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kdt.team04.common.ApiResponse;
 import com.kdt.team04.common.exception.NotAuthenticationException;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalRequest;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalResponse;
 import com.kdt.team04.domain.matches.proposal.service.MatchProposalService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,5 +40,13 @@ public class MatchProposalController {
 		}
 
 		matchProposalService.create(jwtAuthentication.id(), matchId, request);
+	}
+
+	@GetMapping
+	@Operation(summary = "신청 목록 조회", description = "해당 대결의 신청 목록이 조회된다.")
+	public ApiResponse<List<MatchProposalResponse.Chat>> findAllChats(@PathVariable Long matchId) {
+		List<MatchProposalResponse.Chat> proposals = matchProposalService.findAllProposals(matchId);
+
+		return new ApiResponse<>(proposals);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchChatPartitionByProposalIdQueryDto.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchChatPartitionByProposalIdQueryDto.java
@@ -1,0 +1,39 @@
+package com.kdt.team04.domain.matches.proposal.dto;
+
+import java.math.BigInteger;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class MatchChatPartitionByProposalIdQueryDto {
+	private final Long rowNumber;
+	private final Long matchProposalId;
+	private final String lastChat;
+
+	public MatchChatPartitionByProposalIdQueryDto(BigInteger rowNumber, BigInteger matchProposalId, String lastChat) {
+		this.rowNumber = rowNumber.longValue();
+		this.matchProposalId = matchProposalId.longValue();
+		this.lastChat = lastChat;
+	}
+
+	public Long getRowNumber() {
+		return rowNumber;
+	}
+
+	public Long getMatchProposalId() {
+		return matchProposalId;
+	}
+
+	public String getLastChat() {
+		return lastChat;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("rowNumber", rowNumber)
+			.append("matchProposalId", matchProposalId)
+			.append("lastChat", lastChat)
+			.toString();
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchChatResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchChatResponse.java
@@ -1,0 +1,11 @@
+package com.kdt.team04.domain.matches.proposal.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MatchChatResponse() {
+
+	public record LastChat(
+		@Schema(description = "마지막 채팅 내용")
+		String content
+	) {}
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalResponse.java
@@ -1,0 +1,22 @@
+package com.kdt.team04.domain.matches.proposal.dto;
+
+import com.kdt.team04.domain.user.dto.UserResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MatchProposalResponse() {
+
+	public record Chat(
+		@Schema(description = "매칭 신청 아이디")
+		Long id,
+
+		@Schema(description = "매칭 신청 메시지")
+		String content,
+
+		@Schema(description = "채팅 대상")
+		UserResponse.ChatTargetProfile target,
+
+		@Schema(description = "마지막 채팅 정보")
+		MatchChatResponse.LastChat lastChat
+	) {}
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchChatRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchChatRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kdt.team04.domain.matches.proposal.entity.MatchChat;
 
-public interface MatchChatRepository extends JpaRepository<MatchChat, Long> {
+public interface MatchChatRepository extends JpaRepository<MatchChat, Long>, MatchChatRepositoryCustom {
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchChatRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchChatRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.kdt.team04.domain.matches.proposal.repository;
+
+import java.util.List;
+
+import com.kdt.team04.domain.matches.proposal.dto.MatchChatPartitionByProposalIdQueryDto;
+
+public interface MatchChatRepositoryCustom {
+
+	List<MatchChatPartitionByProposalIdQueryDto> findAllPartitionByProposalIdOrderByChattedAtDesc(List<Long> matchProposalIds);
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchChatRepositoryCustomImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchChatRepositoryCustomImpl.java
@@ -1,0 +1,40 @@
+package com.kdt.team04.domain.matches.proposal.repository;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import org.qlrm.mapper.JpaResultMapper;
+import org.springframework.stereotype.Repository;
+
+import com.kdt.team04.domain.matches.proposal.dto.MatchChatPartitionByProposalIdQueryDto;
+
+@Repository
+public class MatchChatRepositoryCustomImpl implements MatchChatRepositoryCustom {
+
+	private final EntityManager em;
+
+	public MatchChatRepositoryCustomImpl(EntityManager em) {
+		this.em = em;
+	}
+
+	@Override
+	public List<MatchChatPartitionByProposalIdQueryDto> findAllPartitionByProposalIdOrderByChattedAtDesc(List<Long> matchProposalIds) {
+		String sql =
+			"SELECT ROW_NUMBER() OVER (PARTITION BY match_proposal_id ORDER BY id DESC), match_proposal_id, content" +
+			" FROM match_chat mc" +
+			" WHERE mc.match_proposal_id IN (:matchProposalIds)"
+			;
+
+		JpaResultMapper jpaResultMapper = new JpaResultMapper();
+		Query nativeQuery = em.createNativeQuery(sql)
+			.setParameter("matchProposalIds", matchProposalIds);
+
+		return jpaResultMapper.list(
+			nativeQuery,
+			MatchChatPartitionByProposalIdQueryDto.class
+		);
+	}
+
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
@@ -1,8 +1,15 @@
 package com.kdt.team04.domain.matches.proposal.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
 
 public interface MatchProposalRepository extends JpaRepository<MatchProposal, Long>, MatchProposalRepositoryCustom {
+
+	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH User u ON mp.user.id = u.id WHERE mp.match.id = :matchId")
+	List<MatchProposal> findAllByMatchId(@Param("matchId") Long matchId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
@@ -10,6 +10,6 @@ import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
 
 public interface MatchProposalRepository extends JpaRepository<MatchProposal, Long>, MatchProposalRepositoryCustom {
 
-	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH User u ON mp.user.id = u.id WHERE mp.match.id = :matchId")
-	List<MatchProposal> findAllByMatchId(@Param("matchId") Long matchId);
+	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH User u ON mp.user.id = u.id INNER JOIN Match m ON mp.match.id = m.id WHERE mp.match.id = :matchId AND m.user.id = :authorId")
+	List<MatchProposal> findAllByMatchId(@Param("matchId") Long matchId, @Param("authorId") Long authorId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
@@ -10,6 +10,6 @@ import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
 
 public interface MatchProposalRepository extends JpaRepository<MatchProposal, Long>, MatchProposalRepositoryCustom {
 
-	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH User u ON mp.user.id = u.id INNER JOIN Match m ON mp.match.id = m.id WHERE mp.match.id = :matchId AND m.user.id = :authorId")
-	List<MatchProposal> findAllByMatchId(@Param("matchId") Long matchId, @Param("authorId") Long authorId);
+	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH User u ON mp.user.id = u.id INNER JOIN Match m ON mp.match.id = m.id WHERE mp.match.id = :matchId")
+	List<MatchProposal> findAllByMatchId(@Param("matchId") Long matchId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchChatService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchChatService.java
@@ -1,7 +1,11 @@
 package com.kdt.team04.domain.matches.proposal.service;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.stereotype.Service;
@@ -10,10 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kdt.team04.common.exception.BusinessException;
 import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.domain.matches.match.entity.MatchStatus;
+import com.kdt.team04.domain.matches.proposal.dto.MatchChatConverter;
+import com.kdt.team04.domain.matches.proposal.dto.MatchChatPartitionByProposalIdQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.MatchChatResponse;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
 import com.kdt.team04.domain.matches.proposal.entity.MatchChat;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
-import com.kdt.team04.domain.matches.proposal.dto.MatchChatConverter;
-import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
 import com.kdt.team04.domain.matches.proposal.repository.MatchChatRepository;
 
 @Service
@@ -74,5 +80,19 @@ public class MatchChatService {
 				targetId
 			)
 		);
+	}
+
+	public Map<Long, MatchChatResponse.LastChat> findAllLastChats(List<Long> matchProposalIds) {
+		List<MatchChatPartitionByProposalIdQueryDto> chatQueryDtos
+			= matchChatRepository.findAllPartitionByProposalIdOrderByChattedAtDesc(matchProposalIds);
+
+		Map<Long, MatchChatResponse.LastChat> lastChats = chatQueryDtos.stream()
+			.filter(chat -> chat.getRowNumber() == 1L)
+			.collect(toMap(
+				MatchChatPartitionByProposalIdQueryDto::getMatchProposalId,
+				chat -> new MatchChatResponse.LastChat(chat.getLastChat())
+			));
+
+		return lastChats;
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -115,7 +115,14 @@ public class MatchProposalService {
 	}
 
 	public List<MatchProposalResponse.Chat> findAllProposals(Long matchId, Long authorId) {
-		List<MatchProposal> matchProposals = proposalRepository.findAllByMatchId(matchId, authorId);
+		MatchResponse.MatchAuthorResponse matchAuthor = matchService.findMatchAuthorById(matchId);
+		if (matchAuthor.author().id() != authorId) {
+			throw new BusinessException(ErrorCode.MATCH_ACCESS_DENIED,
+				MessageFormat.format("Don't have permission to access match with matchId={0}, authorId={1}, userId={2}",
+					matchId, matchAuthor.author().id(), authorId));
+		}
+
+		List<MatchProposal> matchProposals = proposalRepository.findAllByMatchId(matchId);
 		if (matchProposals.isEmpty()) {
 			throw new BusinessException(ErrorCode.MATCH_PROPOSAL_NOT_FOUND,
 				MessageFormat.format("Match proposal not found with matchId={0}, authorId={1}", matchId, authorId));

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -1,5 +1,6 @@
 package com.kdt.team04.domain.matches.proposal.service;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -113,8 +114,13 @@ public class MatchProposalService {
 			.build();
 	}
 
-	public List<MatchProposalResponse.Chat> findAllProposals(Long matchId) {
-		List<MatchProposal> matchProposals = proposalRepository.findAllByMatchId(matchId);
+	public List<MatchProposalResponse.Chat> findAllProposals(Long matchId, Long authorId) {
+		List<MatchProposal> matchProposals = proposalRepository.findAllByMatchId(matchId, authorId);
+		if (matchProposals.isEmpty()) {
+			throw new BusinessException(ErrorCode.MATCH_PROPOSAL_NOT_FOUND,
+				MessageFormat.format("Match proposal not found with matchId={0}, authorId={1}", matchId, authorId));
+		}
+
 		List<Long> matchProposalIds = matchProposals.stream()
 			.map(MatchProposal::getId)
 			.toList();

--- a/src/main/java/com/kdt/team04/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/kdt/team04/domain/user/dto/UserResponse.java
@@ -54,4 +54,9 @@ public record UserResponse(
 		Long id,
 		@Schema(description = "회원 닉네임")
 		String nickname) {}
+
+	public record ChatTargetProfile(
+		@Schema(description = "채팅 상대 닉네임")
+		String nickname
+	) {}
 }

--- a/src/main/resources/db/seed/R__022_Seed_match_proposal.sql
+++ b/src/main/resources/db/seed/R__022_Seed_match_proposal.sql
@@ -4,3 +4,6 @@ INSERT IGNORE INTO match_proposal(id, match_id, content, user_id, team_id, statu
 INSERT IGNORE INTO match_proposal(id, match_id, content, user_id, team_id, status) VALUES(4, 5, 'ㄹㅇ ㅋㅋ', 3, null, 'WAITING');
 INSERT IGNORE INTO match_proposal(id, match_id, content, user_id, team_id, status) VALUES(5, 5, 'ㅇㅇ', 2, null, 'WAITING');
 INSERT IGNORE INTO match_proposal(id, match_id, content, user_id, team_id, status) VALUES(6, 5, 'ㅎㅇ', 4, null, 'APPROVED');
+
+INSERT IGNORE INTO match_proposal(id, match_id, content, user_id, team_id, status) VALUES(7, 1, 'ㅇㅇ', 2, 3, 'APPROVED');
+INSERT IGNORE INTO match_proposal(id, match_id, content, user_id, team_id, status) VALUES(8, 1, 'ㅇㅇ', 3, 4, 'APPROVED');

--- a/src/main/resources/db/seed/R__023_Seed_match_chat.sql
+++ b/src/main/resources/db/seed/R__023_Seed_match_chat.sql
@@ -3,3 +3,11 @@ INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content
 INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (3, 1, 1, 5, '저녁 6시까지 한강으로 오삼', now());
 INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (4, 1, 5, 1, 'ㅇㅋ 갈게유', now());
 INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (5, 1, 1, 5, '가즈아!', now());
+
+INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (6, 7, 1, 2, '하실?', now());
+INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (7, 7, 2, 1, 'ㅇㅇ', now());
+INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (8, 7, 1, 2, '2번 마지막 채팅', now());
+
+INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (9, 8, 1, 3, 'ㅎㅇ', now());
+INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (10, 8, 3, 1, '하는 거임?', now());
+INSERT IGNORE INTO match_chat(id, match_proposal_id, user_id, target_id, content, chatted_at) VALUES (11, 8, 1, 3, '3번 마지막 채팅', now());

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
@@ -2,11 +2,19 @@ package com.kdt.team04.domain.matches.proposal.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.is;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
 
 import javax.persistence.EntityManager;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +25,12 @@ import com.kdt.team04.common.exception.BusinessException;
 import com.kdt.team04.domain.matches.match.entity.Match;
 import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
+import com.kdt.team04.domain.matches.proposal.dto.MatchChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalRequest;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalResponse;
+import com.kdt.team04.domain.matches.proposal.entity.MatchChat;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.user.entity.User;
@@ -146,5 +159,93 @@ class MatchProposalServiceIntegrationTest {
 		//when, then
 		assertThatThrownBy(() -> matchProposalService.create(proposer.getId(), match.getId(), request))
 			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	@DisplayName("매칭 ID로 매칭 신청 목록을 조회한다.")
+	void test_findAllLastChats() {
+		//given
+		String lastChat = "마지막 채팅";
+
+		User author = new User("author", "authorNik", "aA1234!");
+		User target = new User("target", "targetNik", "aA1234!");
+		Team authorTeam = Team.builder()
+			.name("authorTeam")
+			.description("first team")
+			.sportsCategory(SportsCategory.SOCCER)
+			.leader(author)
+			.build();
+		Team targetTeam = Team.builder()
+			.name("targetTeam")
+			.description("first team")
+			.sportsCategory(SportsCategory.SOCCER)
+			.leader(target)
+			.build();
+		entityManager.persist(author);
+		entityManager.persist(target);
+		entityManager.persist(authorTeam);
+		entityManager.persist(targetTeam);
+
+		Match match = Match.builder()
+			.title("덤벼라!")
+			.status(MatchStatus.WAITING)
+			.matchDate(LocalDate.now())
+			.matchType(MatchType.TEAM_MATCH)
+			.participants(3)
+			.user(author)
+			.team(authorTeam)
+			.sportsCategory(SportsCategory.SOCCER)
+			.content("축구 하실?")
+			.build();
+		entityManager.persist(match);
+
+		List<MatchProposal> proposals = new ArrayList<>();
+		IntStream.range(1, 3)
+			.forEach(id -> {
+				MatchProposal matchProposal = MatchProposal.builder()
+					.match(match)
+					.content("덤벼라! 나는 " + id)
+					.user(target)
+					.team(targetTeam)
+					.status(MatchProposalStatus.APPROVED)
+					.build();
+
+				proposals.add(matchProposal);
+				entityManager.persist(matchProposal);
+			});
+
+		List<MatchChat> chats = new ArrayList<>();
+		proposals.forEach(proposal -> {
+			IntStream.range(1, 5)
+				.forEach(id -> {
+					MatchChat chat = MatchChat.builder()
+						.proposal(proposal)
+						.user(author)
+						.target(target)
+						.content(id == 4 ? lastChat + proposal.getId() : "칫챗")
+						.chattedAt(LocalDateTime.now())
+						.build();
+					chats.add(chat);
+					entityManager.persist(chat);
+				});
+		});
+
+		Map<Long, String> expectedChats = new HashMap<>();
+		proposals.forEach(proposal -> {
+			expectedChats.put(proposal.getId(), lastChat + proposal.getId());
+		});
+
+		//when
+		List<MatchProposalResponse.Chat> foundProposlas = matchProposalService.findAllProposals(match.getId());
+
+		//then
+		assertThat(foundProposlas).hasSize(2);
+		foundProposlas.forEach(proposal -> {
+			assertThat(proposal.id()).isNotNull();
+			assertThat(proposal.target()).isNotNull();
+			assertThat(proposal.lastChat()).isNotNull();
+			assertThat(proposal.target().nickname()).isEqualTo(target.getNickname());
+			assertThat(proposal.lastChat().content()).isEqualTo(expectedChats.get(proposal.id()));
+		});
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-280] feat: 매칭 신청 목록 조회(By 매칭 ID) 기능 개발](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/0299c8bc8d16b70e7408d071f52256d9737ec8e3)
- JPQL 에서 row_number 함수를 지원하지 않아 네이티브 쿼리를 사용했고, 
   DTO 매핑을 위해 QLRM 라이브러리르 사용 했습니다.
- 매칭 신청, 채팅 시드 파일 수정

### [[DK-280] test: 매칭 신청 목록 조회(By 매칭 ID) 서비스 테스트 작성](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/17394512b1f9a6449d5f9baf911d5a378c185c27)
- 테스트 코드 작성

## ✅ 추가 작업 단위
로그인 사용자 검증을 위해서 매칭 신청 목록 조회에 조건문 추가했습니다.
이러나 저러나 신청 목록이 존재하지 않는 경우에는 **빈값 오류를 반환**하도록 했습니다.
(사용자에게 너는 권한 없어 라는 오류를 친절하게 보여줄 필요가 있을까 싶었습니다.)

### 해당 커밋 내용만 확인 부탁드릴게요.

### 😓 아 테스트는 분리 해야 했는데, 깜빡 했네요. (다음 기회에... 🏃🏻‍♂️)

[DK-280]: https://insta-kkyu.atlassian.net/browse/DK-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-280]: https://insta-kkyu.atlassian.net/browse/DK-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ