### PR TITLE
[Dk-321] 팀 생성 및 매칭 신청 제한 사항 추가 

### DIFF
--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -1,7 +1,6 @@
 package com.kdt.team04.domain.matches.match.service;
 
 import java.text.MessageFormat;
-import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,8 +91,8 @@ public class MatchService {
 		}
 
 		TeamResponse teamResponse = teamGiver.findById(request.teamId());
-		verifyLeader(userId, request.teamId(), teamResponse.leader().id());
-		verifyTeamMemberCount(request.participants(), request.teamId());
+		teamGiver.verifyLeader(userId, request.teamId(), teamResponse.leader().id());
+		teamMemberGiver.hasEnoughMemberCount(request.participants(), request.teamId());
 
 		User teamLeader = userConverter.toUser(teamResponse.leader());
 		Team team = teamConverter.toTeam(teamResponse, teamLeader);
@@ -145,22 +144,5 @@ public class MatchService {
 		}
 
 		return matchConverter.toMatchResponse(foundMatch, authorResponse);
-	}
-
-	private void verifyLeader(Long userId, Long teamId, Long leaderId) {
-		if (!Objects.equals(userId, leaderId)) {
-			throw new BusinessException(ErrorCode.NOT_TEAM_LEADER,
-				MessageFormat.format("teamId = {0} , userId = {1}", teamId, userId));
-		}
-	}
-
-	private void verifyTeamMemberCount(int participants, Long teamId) {
-		int teamMemberCount = teamMemberGiver.countByTeamId(teamId);
-
-		if (teamMemberCount < participants) {
-			throw new BusinessException(ErrorCode.INVALID_PARTICIPANTS,
-				MessageFormat.format("TeamMemberCount = {0} participants = {1}",
-					teamMemberCount, participants));
-		}
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
@@ -2,10 +2,12 @@ package com.kdt.team04.domain.team.service;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kdt.team04.common.exception.BusinessException;
 import com.kdt.team04.common.exception.EntityNotFoundException;
 import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.domain.team.dto.TeamConverter;
@@ -44,5 +46,12 @@ public class TeamGiverService {
 					team.getId(), team.getName(), team.getSportsCategory()
 				)
 			).toList();
+	}
+
+	public void verifyLeader(Long userId, Long teamId, Long leaderId) {
+		if (!Objects.equals(userId, leaderId)) {
+			throw new BusinessException(ErrorCode.NOT_TEAM_LEADER,
+				MessageFormat.format("teamId = {0} , userId = {1}", teamId, userId));
+		}
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/teammember/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/repository/TeamMemberRepository.java
@@ -14,4 +14,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
 	@Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team t JOIN FETCH tm.user u WHERE t.id = :teamId")
 	List<TeamMember> findAllByTeamId(@Param("teamId") Long teamId);
+
+	int countAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/kdt/team04/domain/teammember/service/TeamMemberGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/service/TeamMemberGiverService.java
@@ -46,4 +46,7 @@ public class TeamMemberGiverService {
 		teamMemberRepository.save(teamMember);
 	}
 
+	public int countByTeamId(Long teamId){
+		return teamMemberRepository.countAllByTeamId(teamId);
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/teammember/service/TeamMemberGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/teammember/service/TeamMemberGiverService.java
@@ -1,10 +1,13 @@
 package com.kdt.team04.domain.teammember.service;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kdt.team04.common.exception.BusinessException;
+import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.teammember.dto.TeamMemberConverter;
 import com.kdt.team04.domain.teammember.dto.TeamMemberResponse;
@@ -46,7 +49,17 @@ public class TeamMemberGiverService {
 		teamMemberRepository.save(teamMember);
 	}
 
-	public int countByTeamId(Long teamId){
+	public int countByTeamId(Long teamId) {
 		return teamMemberRepository.countAllByTeamId(teamId);
+	}
+
+	public void hasEnoughMemberCount(int participants, Long teamId) {
+		int teamMemberCount = teamMemberRepository.countAllByTeamId(teamId);
+
+		if (teamMemberCount < participants) {
+			throw new BusinessException(ErrorCode.INVALID_PARTICIPANTS,
+				MessageFormat.format("TeamMemberCount = {0} participants = {1}",
+					teamMemberCount, participants));
+		}
 	}
 }

--- a/src/main/resources/db/seed/R__013_Seed_team_member.sql
+++ b/src/main/resources/db/seed/R__013_Seed_team_member.sql
@@ -7,7 +7,7 @@ INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (4, 2, 1, 'LEA
 INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (5, 3, 2, 'LEADER');
 INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (6, 4, 3, 'LEADER');
 
-INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (4, 5, 4, 'LEADER');
-INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (5, 5, 9, 'MEMBER');
-INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (6, 5, 10, 'MEMBER');
-INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (7, 5, 11, 'MEMBER');
+INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (7, 5, 4, 'LEADER');
+INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (8, 5, 9, 'MEMBER');
+INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (9, 5, 10, 'MEMBER');
+INSERT IGNORE INTO team_member(id, team_id, user_id, role) VALUES (10, 5, 11, 'MEMBER');


### PR DESCRIPTION
## ✅  작업 단위

- 팀 총 인원이 매칭 참여 인원보다 적을 경우 팀 생성 및 팀 매칭 신청 요청이 불가능한 로직을 추가했습니다.
- Team Member seed 데이터 PK 중복이 있어 수정했습니다. 

## 🤔 고민 했던 부분


## 🔊 HELP !!
