### PR TITLE
[DK-278] feat: 매칭 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
 	INVALID_PARTICIPANTS("M0004", "Invalid match participants", HttpStatus.BAD_REQUEST),
 	AUTHOR_NOT_MATCHED("M0005", "Author not matched", HttpStatus.BAD_REQUEST),
 	MATCH_ACCESS_DENIED("M0006", "Don't have permission to access match", HttpStatus.FORBIDDEN),
+	MATCH_ALREADY_CHANGED_STATUS("M0007", "Already been changed to that state.", HttpStatus.BAD_REQUEST),
+	MATCH_ENDED("M0008", "Match Already ended.", HttpStatus.BAD_REQUEST),
+	MATCH_CANNOT_UPDATE_END("M0009", "Match cannot update to end.", HttpStatus.BAD_REQUEST),
 
 	//MATCH_PROPOSAL
 	MATCH_PROPOSAL_NOT_FOUND("MP0001", "Not found proposal", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/kdt/team04/domain/matches/match/controller/MatchController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/controller/MatchController.java
@@ -4,6 +4,7 @@ import javax.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,5 +57,19 @@ public class MatchController {
 	@GetMapping("/{id}")
 	public ApiResponse<MatchResponse> getById(@PathVariable Long id) {
 		return new ApiResponse<>(matchService.findById(id));
+	}
+
+	@Operation(summary = "매치 모집 완료 및 취소", description = "매치 공고를 모집 완료 또는 모집 중으로 상태를 변경한다.")
+	@PatchMapping("/{id}")
+	public void updateStatus(
+		@AuthenticationPrincipal JwtAuthentication authentication,
+		@PathVariable Long id,
+		@Valid @RequestBody MatchRequest.MatchStatusUpdateRequest request
+	) {
+		if (authentication == null) {
+			throw new NotAuthenticationException("Not Authenticated");
+		}
+
+		matchService.updateStatusExceptEnd(id, authentication.id(), request.status());
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchRequest.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchRequest.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
 import com.kdt.team04.domain.team.SportsCategory;
 
@@ -47,4 +48,10 @@ public record MatchRequest() {
 		@Schema(description = "매칭 내용, 2자 이상 100자 이하", required = true)
 		String content) {
 	}
+
+	public record MatchStatusUpdateRequest(
+		@NotNull
+		@Schema(description = "매칭 상태")
+		MatchStatus status
+	) { }
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/entity/Match.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/entity/Match.java
@@ -84,6 +84,11 @@ public class Match extends BaseEntity {
 		this.location = location;
 	}
 
+	//== 비지니스 로직 ==//
+	public void updateStatus(MatchStatus status) {
+		this.status = status;
+	}
+
 	public Long getId() {
 		return id;
 	}

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -15,6 +15,7 @@ import com.kdt.team04.domain.matches.match.dto.MatchPagingCursor;
 import com.kdt.team04.domain.matches.match.dto.MatchRequest;
 import com.kdt.team04.domain.matches.match.dto.MatchResponse;
 import com.kdt.team04.domain.matches.match.entity.Match;
+import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
 import com.kdt.team04.domain.matches.match.repository.MatchRepository;
 import com.kdt.team04.domain.team.dto.TeamConverter;
@@ -145,6 +146,35 @@ public class MatchService {
 		}
 
 		return matchConverter.toMatchResponse(foundMatch, authorResponse);
+	}
+
+	@Transactional
+	public void updateStatusExceptEnd(Long id, Long userId, MatchStatus status) {
+		if (Objects.equals(status, MatchStatus.END)) {
+			throw new BusinessException(ErrorCode.MATCH_CANNOT_UPDATE_END,
+				MessageFormat.format("matchId = {0}, userId = {1}, status = {2}", id, userId, status));
+		}
+
+		Match match = matchRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MATCH_NOT_FOUND,
+				MessageFormat.format("matchId = {0}", id)));
+
+		if (!Objects.equals(match.getUser().getId(), userId)) {
+			throw new BusinessException(ErrorCode.MATCH_ACCESS_DENIED,
+				MessageFormat.format("matchId = {0} , userId = {1}", id, userId));
+		}
+
+		if (Objects.equals(match.getStatus(), status)) {
+			throw new BusinessException(ErrorCode.MATCH_ALREADY_CHANGED_STATUS,
+				MessageFormat.format("matchId = {0} , status = {1}", id, status));
+		}
+
+		if (Objects.equals(match.getStatus(), MatchStatus.END)) {
+			throw new BusinessException(ErrorCode.MATCH_ENDED,
+				MessageFormat.format("matchId = {0} , status = {1}", id, status));
+		}
+
+		match.updateStatus(status);
 	}
 
 	public MatchResponse.MatchAuthorResponse findMatchAuthorById(Long id) {

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/entity/MatchProposal.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/entity/MatchProposal.java
@@ -59,6 +59,7 @@ public class MatchProposal extends BaseEntity {
 		this.status = defaultIfNull(status, WAITING);
 	}
 
+	//== 비지니스 로직 ==//
 	public void updateStatus(MatchProposalStatus status) {
 		this.status = status;
 	}

--- a/src/test/java/com/kdt/team04/domain/matches/match/service/MatchServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/match/service/MatchServiceIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -563,5 +564,232 @@ class MatchServiceIntegrationTest {
 		assertThat(foundMatches.values().get(0).id()).isEqualTo(matches.get(matches.size() - 1).getId());
 		assertThat(foundMatches.values().get(4).id()).isEqualTo(matches.get(matches.size() - 5).getId());
 		assertThat(foundMatches.hasNext()).isTrue();
+	}
+
+	@Test
+	@DisplayName("매칭을 모집 완료로 상태 변경한다.")
+	void test_updateStatusExceptEnd_toInGame() {
+		//given
+		User author = new User("author", "author", "aA1234!");
+		Team authorTeam = Team.builder()
+			.name("team1")
+			.description("first team")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(author)
+			.build();
+		entityManager.persist(author);
+		entityManager.persist(authorTeam);
+
+		Match match = Match.builder()
+			.title("match")
+			.status(MatchStatus.WAITING)
+			.matchDate(LocalDate.now())
+			.matchType(MatchType.TEAM_MATCH)
+			.participants(3)
+			.user(author)
+			.team(authorTeam)
+			.sportsCategory(SportsCategory.BADMINTON)
+			.content("content")
+			.build();
+		entityManager.persist(match);
+
+		//when
+		matchService.updateStatusExceptEnd(match.getId(), author.getId(), MatchStatus.IN_GAME);
+
+		//then
+		Match foundMatch = entityManager.find(Match.class, match.getId());
+		assertThat(foundMatch).isNotNull();
+		assertThat(foundMatch.getStatus()).isEqualTo(MatchStatus.IN_GAME);
+	}
+
+	@Test
+	@DisplayName("매칭을 모집 중으로 상태 변경한다.")
+	void test_updateStatusExceptEnd_toWaiting() {
+		//given
+		User author = new User("author", "author", "aA1234!");
+		Team authorTeam = Team.builder()
+			.name("team1")
+			.description("first team")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(author)
+			.build();
+		entityManager.persist(author);
+		entityManager.persist(authorTeam);
+
+		Match match = Match.builder()
+			.title("match")
+			.status(MatchStatus.IN_GAME)
+			.matchDate(LocalDate.now())
+			.matchType(MatchType.TEAM_MATCH)
+			.participants(3)
+			.user(author)
+			.team(authorTeam)
+			.sportsCategory(SportsCategory.BADMINTON)
+			.content("content")
+			.build();
+		entityManager.persist(match);
+
+		//when
+		matchService.updateStatusExceptEnd(match.getId(), author.getId(), MatchStatus.WAITING);
+
+		//then
+		Match foundMatch = entityManager.find(Match.class, match.getId());
+		assertThat(foundMatch).isNotNull();
+		assertThat(foundMatch.getStatus()).isEqualTo(MatchStatus.WAITING);
+	}
+
+	@Nested
+	@DisplayName("매칭을 모집 완료 또는 모집 중으로 상태 변경 시")
+	class UpdateStatusExceptEnd {
+
+		@Test
+		@DisplayName("경기 완료 상태로 변경하는 경우 오류가 발생한다.")
+		void testFail_CanNotUpdateEnd_updateStatusExceptEnd() {
+			//given
+			User author = new User("author", "author", "aA1234!");
+			Team authorTeam = Team.builder()
+				.name("team1")
+				.description("first team")
+				.sportsCategory(SportsCategory.BADMINTON)
+				.leader(author)
+				.build();
+			entityManager.persist(author);
+			entityManager.persist(authorTeam);
+
+			Match match = Match.builder()
+				.title("match")
+				.status(MatchStatus.IN_GAME)
+				.matchDate(LocalDate.now())
+				.matchType(MatchType.TEAM_MATCH)
+				.participants(3)
+				.user(author)
+				.team(authorTeam)
+				.sportsCategory(SportsCategory.BADMINTON)
+				.content("content")
+				.build();
+			entityManager.persist(match);
+
+			//when, then
+			assertThatThrownBy(() -> {
+				matchService.updateStatusExceptEnd(match.getId(), author.getId(), MatchStatus.END);
+			}).isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("매칭이 존재하지 않는 경우 오류가 발생한다.")
+		void testFail_EmptyExceptionBy_updateStatusExceptEnd() {
+			//given
+			User author = new User("author", "author", "aA1234!");
+			entityManager.persist(author);
+
+			Long invalidMatchId = 999L;
+
+			//when, then
+			assertThatThrownBy(() -> {
+				matchService.updateStatusExceptEnd(invalidMatchId, author.getId(), MatchStatus.IN_GAME);
+			}).isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("매칭 작성자가 아닌 경우 오류가 발생한다.")
+		void testFail_Access_DeniedBy_updateStatusExceptEnd() {
+			//given
+			User author = new User("author", "author", "aA1234!");
+			Team authorTeam = Team.builder()
+				.name("team1")
+				.description("first team")
+				.sportsCategory(SportsCategory.BADMINTON)
+				.leader(author)
+				.build();
+			entityManager.persist(author);
+			entityManager.persist(authorTeam);
+
+			Match match = Match.builder()
+				.title("match")
+				.status(MatchStatus.WAITING)
+				.matchDate(LocalDate.now())
+				.matchType(MatchType.TEAM_MATCH)
+				.participants(3)
+				.user(author)
+				.team(authorTeam)
+				.sportsCategory(SportsCategory.BADMINTON)
+				.content("content")
+				.build();
+			entityManager.persist(match);
+
+			User invalidUser = new User("proposer", "proposer", "aA1234!");
+			entityManager.persist(invalidUser);
+
+			//when, then
+			assertThatThrownBy(() -> {
+				matchService.updateStatusExceptEnd(match.getId(), invalidUser.getId(), MatchStatus.IN_GAME);
+			}).isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("이미 변경 상태인 경우 오류가 발생한다.")
+		void testFail_AlreadyChangedBy_updateStatusExceptEnd() {
+			//given
+			User author = new User("author", "author", "aA1234!");
+			Team authorTeam = Team.builder()
+				.name("team1")
+				.description("first team")
+				.sportsCategory(SportsCategory.BADMINTON)
+				.leader(author)
+				.build();
+			entityManager.persist(author);
+			entityManager.persist(authorTeam);
+
+			Match match = Match.builder()
+				.title("match")
+				.status(MatchStatus.IN_GAME)
+				.matchDate(LocalDate.now())
+				.matchType(MatchType.TEAM_MATCH)
+				.participants(3)
+				.user(author)
+				.team(authorTeam)
+				.sportsCategory(SportsCategory.BADMINTON)
+				.content("content")
+				.build();
+			entityManager.persist(match);
+
+			//when, then
+			assertThatThrownBy(() -> {
+				matchService.updateStatusExceptEnd(match.getId(), author.getId(), MatchStatus.IN_GAME);
+			}).isInstanceOf(BusinessException.class);
+		}
+
+		@Test
+		@DisplayName("경기 종료 상태인 경우 오류가 발생한다.")
+		void testFail_MatchEndedBy_updateStatusExceptEnd() {
+			//given
+			User author = new User("author", "author", "aA1234!");
+			Team authorTeam = Team.builder()
+				.name("team1")
+				.description("first team")
+				.sportsCategory(SportsCategory.BADMINTON)
+				.leader(author)
+				.build();
+			entityManager.persist(author);
+			entityManager.persist(authorTeam);
+
+			Match match = Match.builder()
+				.title("match")
+				.status(MatchStatus.END)
+				.matchDate(LocalDate.now())
+				.matchType(MatchType.TEAM_MATCH)
+				.participants(3)
+				.user(author)
+				.team(authorTeam)
+				.sportsCategory(SportsCategory.BADMINTON)
+				.content("content")
+				.build();
+			entityManager.persist(match);
+
+			//when, then
+			assertThatThrownBy(() -> {
+				matchService.updateStatusExceptEnd(match.getId(), author.getId(), MatchStatus.IN_GAME);
+			}).isInstanceOf(BusinessException.class);
+		}
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-278] feat: 매칭 상태 변경 API 구현](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/67751abf7dc8616cb70607256b4f1b7bbd0dfcb2)
- 매칭 상태 변경 API 구현
- 해당 건은 경기 종료는 제외했습니다.
  (경기 종료는 결과와 함께 상태값 변경)
- 테스트 코드와 같은 케이스로 오류가 발생되도록 했습니다.
   - 경기 종료로 변환 시
   - 매칭이 존재하지 않는 경우
   - 작성자가 아닌 경우
   - 같은 값으로 상태 변경하는 경우
   - 경기 종료 상태인 경우

### [[DK-278] test: 매칭 상태 변경 API 테스트 코드 작성](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/f9410595d0b19ec6f513d569a17327ecc9e423e7)
- 테스트 코드 작성
- 성공 케이스도 모집 완료, 모집 중으로 상태 변경되는 분기로 나눴습니다.
  (상태값이 2개인 것도 있고, 체크 구문이 많아 혹시 몰라 나눴습니다. 🫠)

[DK-278]: https://insta-kkyu.atlassian.net/browse/DK-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-278]: https://insta-kkyu.atlassian.net/browse/DK-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ