### PR TITLE
[DK-274] 리뷰 등록 API 구현

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
 	MATCH_ALREADY_CHANGED_STATUS("M0007", "Already been changed to that state.", HttpStatus.BAD_REQUEST),
 	MATCH_ENDED("M0008", "Match Already ended.", HttpStatus.BAD_REQUEST),
 	MATCH_CANNOT_UPDATE_END("M0009", "Match cannot update to end.", HttpStatus.BAD_REQUEST),
+	MATCH_NOT_ENDED("M0010", "Match not ended", HttpStatus.BAD_REQUEST),
 
 	//MATCH_PROPOSAL
 	MATCH_PROPOSAL_NOT_FOUND("MP0001", "Not found proposal", HttpStatus.NOT_FOUND),
@@ -54,7 +55,10 @@ public enum ErrorCode {
 	INVALID_REACT("MP0005", "Invalid react", HttpStatus.BAD_REQUEST),
 
 	//MATCH_CHAT
-	MATCH_CHAT_NOT_CORRECT_CHAT_PARTNER("MC0002", "The chat partner is incorrect.", HttpStatus.BAD_REQUEST);
+	MATCH_CHAT_NOT_CORRECT_CHAT_PARTNER("MC0002", "The chat partner is incorrect.", HttpStatus.BAD_REQUEST),
+
+	//MATCH_REVIEW
+	MATCH_REVIEW_ALREADY_EXISTS("MR0002", "Match review already exists", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/kdt/team04/domain/matches/match/entity/MatchStatus.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/entity/MatchStatus.java
@@ -6,4 +6,8 @@ public enum MatchStatus {
 	public boolean isMatched() {
 		return this != MatchStatus.WAITING;
 	}
+
+	public boolean isEnded() {
+		return this == MatchStatus.END;
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalQueryDto.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalQueryDto.java
@@ -1,0 +1,87 @@
+package com.kdt.team04.domain.matches.proposal.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.kdt.team04.domain.matches.match.entity.MatchStatus;
+import com.kdt.team04.domain.matches.match.entity.MatchType;
+import com.querydsl.core.annotations.QueryProjection;
+
+public class MatchProposalQueryDto {
+	private Long id;
+	private Long proposerId;
+	private Long proposerTeamId;
+
+	private Long matchId;
+	private MatchStatus matchStatus;
+	private MatchType matchType;
+	private Long authorId;
+	private Long authorTeamId;
+
+	@QueryProjection
+	public MatchProposalQueryDto(
+		Long id,
+		Long proposerId,
+		Long proposerTeamId,
+		Long matchId,
+		MatchStatus matchStatus,
+		MatchType matchType,
+		Long authorId,
+		Long authorTeamId
+	) {
+		this.id = id;
+		this.proposerId = proposerId;
+		this.proposerTeamId = proposerTeamId;
+		this.matchId = matchId;
+		this.matchStatus = matchStatus;
+		this.matchType = matchType;
+		this.authorId = authorId;
+		this.authorTeamId = authorTeamId;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Long getProposerId() {
+		return proposerId;
+	}
+
+	public Long getProposerTeamId() {
+		return proposerTeamId;
+	}
+
+	public Long getMatchId() {
+		return matchId;
+	}
+
+	public MatchStatus getMatchStatus() {
+		return matchStatus;
+	}
+
+	public MatchType getMatchType() {
+		return matchType;
+	}
+
+	public Long getAuthorId() {
+		return authorId;
+	}
+
+	public Long getAuthorTeamId() {
+		return authorTeamId;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("id", id)
+			.append("proposerId", proposerId)
+			.append("proposerTeamId", proposerTeamId)
+			.append("matchId", matchId)
+			.append("matchStatus", matchStatus)
+			.append("matchType", matchType)
+			.append("authorId", authorId)
+			.append("authorTeamId", authorTeamId)
+			.toString();
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalSimpleQueryDto.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/MatchProposalSimpleQueryDto.java
@@ -7,15 +7,15 @@ import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.querydsl.core.annotations.QueryProjection;
 
-public class MatchProposalQueryDto {
-	Long id;
-	MatchProposalStatus status;
-	Long matchProposerId;
-	Long matchAuthorId;
-	MatchStatus matchStatus;
+public class MatchProposalSimpleQueryDto {
+	private Long id;
+	private MatchProposalStatus status;
+	private Long matchProposerId;
+	private Long matchAuthorId;
+	private MatchStatus matchStatus;
 
 	@QueryProjection
-	public MatchProposalQueryDto(
+	public MatchProposalSimpleQueryDto(
 		Long id,
 		MatchProposalStatus status,
 		Long matchProposerId,

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustom.java
@@ -2,8 +2,10 @@ package com.kdt.team04.domain.matches.proposal.repository;
 
 import java.util.Optional;
 
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
 
 public interface MatchProposalRepositoryCustom {
 	Optional<MatchProposalSimpleQueryDto> findSimpleProposalById(Long id);
+	Optional<MatchProposalQueryDto> findFixedProposalByMatchId(Long matchId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustom.java
@@ -2,8 +2,8 @@ package com.kdt.team04.domain.matches.proposal.repository;
 
 import java.util.Optional;
 
-import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
 
 public interface MatchProposalRepositoryCustom {
-	Optional<MatchProposalQueryDto> findSimpleProposalById(Long id);
+	Optional<MatchProposalSimpleQueryDto> findSimpleProposalById(Long id);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustomImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustomImpl.java
@@ -7,8 +7,8 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
-import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
-import com.kdt.team04.domain.matches.proposal.dto.QMatchProposalQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.QMatchProposalSimpleQueryDto;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -22,9 +22,9 @@ public class MatchProposalRepositoryCustomImpl implements MatchProposalRepositor
 	}
 
 	@Override
-	public Optional<MatchProposalQueryDto> findSimpleProposalById(Long id) {
-		MatchProposalQueryDto matchProposalDto = queryFactory
-			.select(new QMatchProposalQueryDto(
+	public Optional<MatchProposalSimpleQueryDto> findSimpleProposalById(Long id) {
+		MatchProposalSimpleQueryDto matchProposalDto = queryFactory
+			.select(new QMatchProposalSimpleQueryDto(
 				Expressions.asNumber(id).as("id"),
 				matchProposal.status,
 				matchProposal.user.id,

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustomImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepositoryCustomImpl.java
@@ -1,14 +1,18 @@
 package com.kdt.team04.domain.matches.proposal.repository;
 
 import static com.kdt.team04.domain.matches.match.entity.QMatch.match;
+import static com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus.FIXED;
 import static com.kdt.team04.domain.matches.proposal.entity.QMatchProposal.matchProposal;
 
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.QMatchProposalQueryDto;
 import com.kdt.team04.domain.matches.proposal.dto.QMatchProposalSimpleQueryDto;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -34,6 +38,30 @@ public class MatchProposalRepositoryCustomImpl implements MatchProposalRepositor
 			.from(matchProposal)
 			.join(match).on(matchProposal.match.id.eq(match.id))
 			.where(matchProposal.id.eq(id))
+			.fetchOne();
+
+		return Optional.ofNullable(matchProposalDto);
+	}
+
+	@Override
+	public Optional<MatchProposalQueryDto> findFixedProposalByMatchId(Long matchId) {
+		MatchProposalQueryDto matchProposalDto = queryFactory
+			.select(new QMatchProposalQueryDto(
+				matchProposal.id,
+				matchProposal.user.id,
+				matchProposal.team.id,
+				Expressions.constant(matchId),
+				match.status,
+				match.matchType,
+				match.user.id,
+				match.team.id
+			))
+			.from(matchProposal)
+			.join(match).on(matchProposal.match.id.eq(match.id))
+			.where(
+				match.id.eq(matchId),
+				matchProposal.status.eq(FIXED)
+			)
 			.fetchOne();
 
 		return Optional.ofNullable(matchProposalDto);

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchChatService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchChatService.java
@@ -17,7 +17,7 @@ import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.proposal.dto.MatchChatConverter;
 import com.kdt.team04.domain.matches.proposal.dto.MatchChatPartitionByProposalIdQueryDto;
 import com.kdt.team04.domain.matches.proposal.dto.MatchChatResponse;
-import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
 import com.kdt.team04.domain.matches.proposal.entity.MatchChat;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.kdt.team04.domain.matches.proposal.repository.MatchChatRepository;
@@ -42,7 +42,7 @@ public class MatchChatService {
 
 	@Transactional
 	public void chat(Long proposalId, Long writerId, Long targetId, String content, LocalDateTime chattedAt) {
-		MatchProposalQueryDto matchProposalDto = matchProposalGiver.findSimpleProposalById(proposalId);
+		MatchProposalSimpleQueryDto matchProposalDto = matchProposalGiver.findSimpleProposalById(proposalId);
 
 		if (matchProposalDto.getStatus() != MatchProposalStatus.APPROVED) {
 			throw new BusinessException(

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.team04.common.exception.EntityNotFoundException;
 import com.kdt.team04.common.exception.ErrorCode;
-import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
 import com.kdt.team04.domain.matches.proposal.repository.MatchProposalRepository;
 
 @Service
@@ -20,8 +20,8 @@ public class MatchProposalGiverService {
 		this.matchProposalRepository = matchProposalRepository;
 	}
 
-	public MatchProposalQueryDto findSimpleProposalById(Long id) {
-		MatchProposalQueryDto matchProposal = matchProposalRepository.findSimpleProposalById(id)
+	public MatchProposalSimpleQueryDto findSimpleProposalById(Long id) {
+		MatchProposalSimpleQueryDto matchProposal = matchProposalRepository.findSimpleProposalById(id)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MATCH_PROPOSAL_NOT_FOUND,
 				MessageFormat.format("matchProposalId = {0}", id)));
 

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.team04.common.exception.EntityNotFoundException;
 import com.kdt.team04.common.exception.ErrorCode;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
 import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
 import com.kdt.team04.domain.matches.proposal.repository.MatchProposalRepository;
 
@@ -24,6 +25,14 @@ public class MatchProposalGiverService {
 		MatchProposalSimpleQueryDto matchProposal = matchProposalRepository.findSimpleProposalById(id)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MATCH_PROPOSAL_NOT_FOUND,
 				MessageFormat.format("matchProposalId = {0}", id)));
+
+		return matchProposal;
+	}
+
+	public MatchProposalQueryDto findFixedProposalByMatchId(Long matchId) {
+		MatchProposalQueryDto matchProposal = matchProposalRepository.findFixedProposalByMatchId(matchId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MATCH_PROPOSAL_NOT_FOUND,
+				MessageFormat.format("matchId = {0}", matchId)));
 
 		return matchProposal;
 	}

--- a/src/main/java/com/kdt/team04/domain/matches/review/controller/MatchReviewController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/controller/MatchReviewController.java
@@ -1,0 +1,42 @@
+package com.kdt.team04.domain.matches.review.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kdt.team04.common.exception.NotAuthenticationException;
+import com.kdt.team04.common.security.jwt.JwtAuthentication;
+import com.kdt.team04.domain.matches.review.dto.MatchReviewRequest;
+import com.kdt.team04.domain.matches.review.service.MatchReviewService;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+@RestController
+@RequestMapping("/api/matches/{id}/review")
+public class MatchReviewController {
+
+	private final MatchReviewService matchReviewService;
+
+	public MatchReviewController(MatchReviewService matchReviewService) {
+		this.matchReviewService = matchReviewService;
+	}
+
+	@PostMapping
+	@Operation(summary = "경기 후기 등록", description = "경기 종료 후 경기 후기를 등록한다.")
+	public void review(
+		@AuthenticationPrincipal JwtAuthentication authentication,
+		@PathVariable Long id,
+		@Valid @RequestBody MatchReviewRequest request
+	) {
+		if (authentication == null) {
+			throw new NotAuthenticationException("Not Authenticated");
+		}
+
+		matchReviewService.review(id, request.review(), authentication.id());
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/matches/review/dto/MatchReviewConverter.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/dto/MatchReviewConverter.java
@@ -1,0 +1,49 @@
+package com.kdt.team04.domain.matches.review.dto;
+
+import org.springframework.stereotype.Component;
+
+import com.kdt.team04.domain.matches.match.entity.Match;
+import com.kdt.team04.domain.matches.review.entity.MatchReview;
+import com.kdt.team04.domain.matches.review.entity.MatchReviewValue;
+import com.kdt.team04.domain.team.entity.Team;
+import com.kdt.team04.domain.user.entity.User;
+
+@Component
+public class MatchReviewConverter {
+
+	public MatchReview toTeamReview(
+		Long matchId,
+		MatchReviewValue review,
+		Long teamId,
+		Long targetTeamId
+	) {
+		Match match = Match.builder().id(matchId).build();
+		Team team = Team.builder().id(teamId).build();
+		Team target = Team.builder().id(targetTeamId).build();
+
+		return MatchReview.builder()
+			.match(match)
+			.review(review)
+			.team(team)
+			.targetTeam(target)
+			.build();
+	}
+
+	public MatchReview toIndividualReview(
+		Long matchId,
+		MatchReviewValue review,
+		Long userId,
+		Long targetId
+	) {
+		Match match = Match.builder().id(matchId).build();
+		User user = User.builder().id(userId).build();
+		User target = User.builder().id(targetId).build();
+
+		return MatchReview.builder()
+			.match(match)
+			.review(review)
+			.user(user)
+			.targetUser(target)
+			.build();
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/matches/review/dto/MatchReviewRequest.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/dto/MatchReviewRequest.java
@@ -1,0 +1,15 @@
+package com.kdt.team04.domain.matches.review.dto;
+
+import javax.validation.constraints.NotNull;
+
+import com.kdt.team04.domain.matches.review.entity.MatchReviewValue;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MatchReviewRequest(
+
+	@NotNull
+	@Schema(description = "리뷰 (최고에요 | 좋아요 | 별로에요)")
+	MatchReviewValue review
+) {
+}

--- a/src/main/java/com/kdt/team04/domain/matches/review/repository/MatchReviewRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/repository/MatchReviewRepository.java
@@ -1,8 +1,13 @@
 package com.kdt.team04.domain.matches.review.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kdt.team04.domain.matches.review.entity.MatchReview;
 
 public interface MatchReviewRepository extends JpaRepository<MatchReview, Long>, MatchReviewRepositoryCustom {
+
 }

--- a/src/main/java/com/kdt/team04/domain/matches/review/repository/MatchReviewRepositoryCustom.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/repository/MatchReviewRepositoryCustom.java
@@ -6,4 +6,6 @@ public interface MatchReviewRepositoryCustom {
 	MatchReviewResponse.TotalCount getTeamTotalCount(Long teamId);
 
 	MatchReviewResponse.TotalCount getTeamTotalCountByUserId(Long userId);
+
+	boolean existsByMatchIdAndUserId(Long matchId, Long userId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/review/repository/MatchReviewRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/repository/MatchReviewRepositoryImpl.java
@@ -43,4 +43,17 @@ public class MatchReviewRepositoryImpl implements MatchReviewRepositoryCustom {
 			.where(matchReview.targetUser.id.eq(userId))
 			.fetchOne();
 	}
+
+	@Override
+	public boolean existsByMatchIdAndUserId(Long matchId, Long userId) {
+		Integer exists = jpaQueryFactory
+			.selectOne()
+			.from(matchReview)
+			.where(
+				matchReview.match.id.eq(matchId),
+				matchReview.user.id.eq(userId)
+			).fetchFirst();
+
+		return exists != null;
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/review/service/MatchReviewService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/service/MatchReviewService.java
@@ -1,0 +1,99 @@
+package com.kdt.team04.domain.matches.review.service;
+
+import static com.kdt.team04.domain.matches.match.entity.MatchType.INDIVIDUAL_MATCH;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kdt.team04.common.exception.BusinessException;
+import com.kdt.team04.common.exception.ErrorCode;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
+import com.kdt.team04.domain.matches.proposal.service.MatchProposalGiverService;
+import com.kdt.team04.domain.matches.review.dto.MatchReviewConverter;
+import com.kdt.team04.domain.matches.review.entity.MatchReview;
+import com.kdt.team04.domain.matches.review.entity.MatchReviewValue;
+import com.kdt.team04.domain.matches.review.repository.MatchReviewRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class MatchReviewService {
+
+	private final MatchReviewRepository matchReviewRepository;
+	private final MatchProposalGiverService matchProposalGiver;
+
+	private final MatchReviewConverter matchReviewConverter;
+
+	public MatchReviewService(
+		MatchReviewRepository matchReviewRepository,
+		MatchProposalGiverService matchProposalGiver,
+		MatchReviewConverter matchReviewConverter
+	) {
+		this.matchReviewRepository = matchReviewRepository;
+		this.matchProposalGiver = matchProposalGiver;
+		this.matchReviewConverter = matchReviewConverter;
+	}
+
+	@Transactional
+	public Long review(Long matchId, MatchReviewValue review, Long userId) {
+		MatchProposalQueryDto proposalQueryDto = matchProposalGiver.findFixedProposalByMatchId(matchId);
+
+		if (!proposalQueryDto.getMatchStatus().isEnded()) {
+			throw new BusinessException(ErrorCode.MATCH_NOT_ENDED,
+				MessageFormat.format("Match not ended with matchId = {0}, userId = {1}", matchId, userId));
+		}
+
+		if (!Objects.equals(proposalQueryDto.getProposerId(), userId)
+			&& !Objects.equals(proposalQueryDto.getAuthorId(), userId)
+		) {
+			throw new BusinessException(ErrorCode.MATCH_ACCESS_DENIED,
+				MessageFormat.format("matchId = {0} , userId = {1}", matchId, userId));
+		}
+
+		boolean existsReview = matchReviewRepository.existsByMatchIdAndUserId(matchId, userId);
+		if (existsReview) {
+			throw new BusinessException(ErrorCode.MATCH_REVIEW_ALREADY_EXISTS,
+				MessageFormat.format("matchId = {0}, userId = {1}", matchId, userId));
+		}
+
+		MatchReview matchReview = proposalQueryDto.getMatchType() == INDIVIDUAL_MATCH ?
+			createIndividualReview(proposalQueryDto, review, userId) :
+			createTeamReview(proposalQueryDto, review, userId);
+
+		matchReviewRepository.save(matchReview);
+
+		return matchReview.getId();
+	}
+
+	private MatchReview createTeamReview(
+		MatchProposalQueryDto proposalDto,
+		MatchReviewValue review,
+		Long loginId
+	) {
+		Long teamId = Objects.equals(proposalDto.getAuthorId(), loginId) ?
+			proposalDto.getAuthorTeamId() :
+			proposalDto.getProposerTeamId();
+		Long targetTeamId = Objects.equals(proposalDto.getAuthorId(), loginId) ?
+			proposalDto.getProposerTeamId() :
+			proposalDto.getAuthorTeamId();
+
+		return matchReviewConverter.toTeamReview(proposalDto.getMatchId(), review, teamId, targetTeamId);
+	}
+
+	private MatchReview createIndividualReview(
+		MatchProposalQueryDto proposalDto,
+		MatchReviewValue review,
+		Long loginId
+	) {
+		Long userId = Objects.equals(proposalDto.getAuthorId(), loginId) ?
+			proposalDto.getAuthorId() :
+			proposalDto.getProposerId();
+		Long targetId = Objects.equals(proposalDto.getAuthorId(), loginId) ?
+			proposalDto.getProposerId() :
+			proposalDto.getAuthorId();
+
+		return matchReviewConverter.toIndividualReview(proposalDto.getMatchId(), review, userId, targetId);
+	}
+}

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverServiceTest.java
@@ -1,0 +1,221 @@
+package com.kdt.team04.domain.matches.proposal.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kdt.team04.common.exception.BusinessException;
+import com.kdt.team04.domain.matches.match.entity.Match;
+import com.kdt.team04.domain.matches.match.entity.MatchStatus;
+import com.kdt.team04.domain.matches.match.entity.MatchType;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalQueryDto;
+import com.kdt.team04.domain.matches.proposal.dto.MatchProposalSimpleQueryDto;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
+import com.kdt.team04.domain.team.SportsCategory;
+import com.kdt.team04.domain.team.entity.Team;
+import com.kdt.team04.domain.user.entity.User;
+
+@Transactional
+@SpringBootTest
+class MatchProposalGiverServiceTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Autowired
+	private MatchProposalGiverService matchProposalGiver;
+
+	@Test
+	@DisplayName("매칭 신청 정보를 간단 조회한다.")
+	void test_findSimpleProposalById() {
+		//given
+		User author = getUser("author");
+		Team authorTeam = getSoccerTeam("author", author);
+		User target = getUser("target");
+		Team targetTeam = getSoccerTeam("target", target);
+		Match match = getSoccerTeamMatch("축구 하실?", 3, MatchStatus.IN_GAME, author, authorTeam);
+
+		MatchProposal matchProposal = MatchProposal.builder()
+			.match(match)
+			.content("덤벼라!")
+			.user(target)
+			.team(targetTeam)
+			.status(MatchProposalStatus.APPROVED)
+			.build();
+
+		entityManager.persist(author);
+		entityManager.persist(authorTeam);
+		entityManager.persist(target);
+		entityManager.persist(targetTeam);
+		entityManager.persist(match);
+		entityManager.persist(matchProposal);
+
+		MatchProposalSimpleQueryDto expectedQueryDto = new MatchProposalSimpleQueryDto(
+			matchProposal.getId(),
+			matchProposal.getStatus(),
+			matchProposal.getUser().getId(),
+			match.getUser().getId(),
+			match.getStatus()
+		);
+
+		//when
+		MatchProposalSimpleQueryDto simpleProposal = matchProposalGiver.findSimpleProposalById(matchProposal.getId());
+
+		//then
+		assertThat(simpleProposal, samePropertyValuesAs(expectedQueryDto));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 매칭 신청 조회 시, 오류가 발생한다.")
+	void testFail_searchNotExistsProposal() {
+		//given
+		User author = getUser("author");
+		Team authorTeam = getSoccerTeam("author", author);
+		User target = getUser("target");
+		Team targetTeam = getSoccerTeam("target", target);
+		Match match = getSoccerTeamMatch("축구 하실?", 3, MatchStatus.IN_GAME, author, authorTeam);
+
+		entityManager.persist(author);
+		entityManager.persist(authorTeam);
+		entityManager.persist(target);
+		entityManager.persist(targetTeam);
+		entityManager.persist(match);
+
+		Long invalidProposalId = 999L;
+
+		//when, then
+		assertThrows(BusinessException.class, () -> {
+			matchProposalGiver.findSimpleProposalById(invalidProposalId);
+		});
+	}
+
+	@Test
+	@DisplayName("경기 종료된 매칭과 상대 정보를 조회한다.")
+	void test_findFixedProposalByMatchId() {
+		//given
+		User author = getUser("author");
+		Team authorTeam = getSoccerTeam("author", author);
+		User target = getUser("target");
+		Team targetTeam = getSoccerTeam("target", target);
+		Match match = getSoccerTeamMatch("축구 하실?", 3, MatchStatus.END, author, authorTeam);
+
+		MatchProposal matchProposal = MatchProposal.builder()
+			.match(match)
+			.content("덤벼라!")
+			.user(target)
+			.team(targetTeam)
+			.status(MatchProposalStatus.FIXED)
+			.build();
+
+		entityManager.persist(author);
+		entityManager.persist(authorTeam);
+		entityManager.persist(target);
+		entityManager.persist(targetTeam);
+		entityManager.persist(match);
+		entityManager.persist(matchProposal);
+
+		MatchProposalQueryDto expectedQueryDto = new MatchProposalQueryDto(
+			matchProposal.getId(),
+			matchProposal.getUser().getId(),
+			matchProposal.getTeam().getId(),
+			match.getId(),
+			match.getStatus(),
+			match.getMatchType(),
+			match.getUser().getId(),
+			match.getTeam().getId()
+		);
+
+		//when
+		MatchProposalQueryDto fixedProposal = matchProposalGiver.findFixedProposalByMatchId(match.getId());
+
+		//then
+		assertThat(fixedProposal, samePropertyValuesAs(expectedQueryDto));
+	}
+
+	@Test
+	@DisplayName("경기 완료가 되었는데, Fixed 된 신청이 없으면 오류가 발생한다.")
+	void testFail_MatchEnded_ButNotExists_FixedProposal() {
+		//given
+		User author = getUser("author");
+		Team authorTeam = getSoccerTeam("author", author);
+		User target = getUser("target");
+		Team targetTeam = getSoccerTeam("target", target);
+		Match match = getSoccerTeamMatch("축구 하실?", 3, MatchStatus.END, author, authorTeam);
+
+		MatchProposal matchProposal = MatchProposal.builder()
+			.match(match)
+			.content("덤벼라!")
+			.user(target)
+			.team(targetTeam)
+			.status(MatchProposalStatus.APPROVED)
+			.build();
+
+		entityManager.persist(author);
+		entityManager.persist(authorTeam);
+		entityManager.persist(target);
+		entityManager.persist(targetTeam);
+		entityManager.persist(match);
+		entityManager.persist(matchProposal);
+
+		//when, then
+		assertThrows(BusinessException.class, () -> {
+			matchProposalGiver.findFixedProposalByMatchId(match.getId());
+		});
+	}
+
+	private static User getUser(String name) {
+		return User.builder()
+			.password("1234")
+			.username(name)
+			.nickname(name + "Nik")
+			.build();
+	}
+
+	private static Team getSoccerTeam(String name, User user) {
+		return Team.builder()
+			.name(name + "-t")
+			.description("we are team " + name)
+			.sportsCategory(SportsCategory.SOCCER)
+			.leader(user)
+			.build();
+	}
+
+	private static Match getSoccerIndividualMatch(String title, int participants, MatchStatus status, User user, Team team) {
+		return Match.builder()
+			.title(title)
+			.sportsCategory(SportsCategory.SOCCER)
+			.matchType(MatchType.INDIVIDUAL_MATCH)
+			.matchDate(LocalDate.now())
+			.participants(participants)
+			.status(status)
+			.user(user)
+			.team(team)
+			.build();
+	}
+
+	private static Match getSoccerTeamMatch(String title, int participants, MatchStatus status, User user, Team team) {
+		return Match.builder()
+			.title(title)
+			.sportsCategory(SportsCategory.SOCCER)
+			.matchType(MatchType.TEAM_MATCH)
+			.matchDate(LocalDate.now())
+			.participants(participants)
+			.status(status)
+			.user(user)
+			.team(team)
+			.build();
+	}
+}

--- a/src/test/java/com/kdt/team04/domain/matches/review/service/MatchReviewServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/review/service/MatchReviewServiceIntegrationTest.java
@@ -1,0 +1,249 @@
+package com.kdt.team04.domain.matches.review.service;
+
+import static com.kdt.team04.domain.matches.review.entity.MatchReviewValue.BEST;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kdt.team04.common.exception.BusinessException;
+import com.kdt.team04.domain.matches.match.entity.Match;
+import com.kdt.team04.domain.matches.match.entity.MatchStatus;
+import com.kdt.team04.domain.matches.match.entity.MatchType;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
+import com.kdt.team04.domain.matches.review.entity.MatchReview;
+import com.kdt.team04.domain.matches.review.repository.MatchReviewRepository;
+import com.kdt.team04.domain.team.SportsCategory;
+import com.kdt.team04.domain.team.entity.Team;
+import com.kdt.team04.domain.user.entity.User;
+
+@Transactional
+@SpringBootTest
+class MatchReviewServiceIntegrationTest {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Autowired
+	private MatchReviewService matchReviewService;
+
+	@Autowired
+	private MatchReviewRepository matchReviewRepository;
+
+	@Test
+	@DisplayName("팀전 종료 후 경기 후기를 등록한다.")
+	void test_review() {
+		//given
+		User author = getUser("author");
+		Team authorTeam = getSoccerTeam("author", author);
+		User target = getUser("target");
+		Team targetTeam = getSoccerTeam("target", target);
+		Match match = getSoccerTeamMatch("축구 하실?", 3, MatchStatus.END, author, authorTeam);
+
+		MatchProposal matchProposal = MatchProposal.builder()
+			.match(match)
+			.content("덤벼라!")
+			.user(target)
+			.team(targetTeam)
+			.status(MatchProposalStatus.FIXED)
+			.build();
+
+		entityManager.persist(author);
+		entityManager.persist(authorTeam);
+		entityManager.persist(target);
+		entityManager.persist(targetTeam);
+		entityManager.persist(match);
+		entityManager.persist(matchProposal);
+
+		//when
+		Long savedId = matchReviewService.review(match.getId(), BEST, author.getId());
+
+		//then
+		assertThat(savedId, notNullValue());
+		MatchReview matchReview = entityManager.find(MatchReview.class, savedId);
+		assertThat(matchReview, notNullValue());
+		assertThat(matchReview.getMatch().getId(), is(match.getId()));
+		assertThat(matchReview.getTeam().getId(), is(authorTeam.getId()));
+		assertThat(matchReview.getTargetTeam().getId(), is(targetTeam.getId()));
+		assertThat(matchReview.getReview(), is(BEST));
+	}
+
+	@Test
+	@DisplayName("개인전 종료 후 경기 후기를 등록한다.")
+	void test_review_individualGame() {
+		//given
+		User author = getUser("author");
+		User target = getUser("target");
+		Match match = getSoccerIndividualMatch("축구 하실?", 1, MatchStatus.END, author, null);
+
+		MatchProposal matchProposal = MatchProposal.builder()
+			.match(match)
+			.content("덤벼라!")
+			.user(target)
+			.team(null)
+			.status(MatchProposalStatus.FIXED)
+			.build();
+
+		entityManager.persist(author);
+		entityManager.persist(target);
+		entityManager.persist(match);
+		entityManager.persist(matchProposal);
+
+		//when
+		Long savedId = matchReviewService.review(match.getId(), BEST, author.getId());
+
+		//then
+		assertThat(savedId, notNullValue());
+		MatchReview matchReview = entityManager.find(MatchReview.class, savedId);
+		assertThat(matchReview, notNullValue());
+		assertThat(matchReview.getMatch().getId(), is(match.getId()));
+		assertThat(matchReview.getUser().getId(), is(author.getId()));
+		assertThat(matchReview.getTargetUser().getId(), is(target.getId()));
+		assertThat(matchReview.getReview(), is(BEST));
+	}
+
+	@Nested
+	@DisplayName("경기 후기 등록 시")
+	class review {
+
+		@Test
+		@DisplayName("경기 종료 상태가 아닌 경우 오류가 발생한다.")
+		void testFail_MatchNotEnded() {
+			User author = getUser("author");
+			User target = getUser("target");
+			Match match = getSoccerIndividualMatch("축구 하실?", 1, MatchStatus.IN_GAME, author, null);
+
+			MatchProposal matchProposal = MatchProposal.builder()
+				.match(match)
+				.content("덤벼라!")
+				.user(target)
+				.team(null)
+				.status(MatchProposalStatus.FIXED)
+				.build();
+
+			entityManager.persist(author);
+			entityManager.persist(target);
+			entityManager.persist(match);
+			entityManager.persist(matchProposal);
+
+			//when, then
+			assertThrows(BusinessException.class, () -> {
+				matchReviewService.review(match.getId(), BEST, author.getId());
+			});
+		}
+
+		@Test
+		@DisplayName("경기 공고 작성자 혹은 신청자가 아닌 경우 오류가 발생한다.")
+		void testFail_AccessDenied() {
+			User author = getUser("author");
+			User target = getUser("target");
+			Match match = getSoccerIndividualMatch("축구 하실?", 1, MatchStatus.END, author, null);
+
+			MatchProposal matchProposal = MatchProposal.builder()
+				.match(match)
+				.content("덤벼라!")
+				.user(target)
+				.team(null)
+				.status(MatchProposalStatus.FIXED)
+				.build();
+
+			entityManager.persist(author);
+			entityManager.persist(target);
+			entityManager.persist(match);
+			entityManager.persist(matchProposal);
+
+			User invalidUser = getUser("invalid");
+			entityManager.persist(invalidUser);
+
+			//when, then
+			assertThrows(BusinessException.class, () -> {
+				matchReviewService.review(match.getId(), BEST, invalidUser.getId());
+			});
+		}
+
+		@Test
+		@DisplayName("해당 사용자 리뷰가 이미 등록된 경우 오류가 발생한다.")
+		void testFail_AlreadyExists() {
+			//given
+			User author = getUser("author");
+			User target = getUser("target");
+			Match match = getSoccerIndividualMatch("축구 하실?", 1, MatchStatus.END, author, null);
+
+			MatchProposal matchProposal = MatchProposal.builder()
+				.match(match)
+				.content("덤벼라!")
+				.user(target)
+				.team(null)
+				.status(MatchProposalStatus.FIXED)
+				.build();
+
+			entityManager.persist(author);
+			entityManager.persist(target);
+			entityManager.persist(match);
+			entityManager.persist(matchProposal);
+
+			matchReviewService.review(match.getId(), BEST, author.getId());
+
+			//when
+			assertThrows(BusinessException.class, () -> {
+				matchReviewService.review(match.getId(), BEST, author.getId());
+			});
+		}
+	}
+
+	private static User getUser(String name) {
+		return User.builder()
+			.password("1234")
+			.username(name)
+			.nickname(name + "Nik")
+			.build();
+	}
+
+	private static Team getSoccerTeam(String name, User user) {
+		return Team.builder()
+			.name(name + "-t")
+			.description("we are team " + name)
+			.sportsCategory(SportsCategory.SOCCER)
+			.leader(user)
+			.build();
+	}
+
+	private static Match getSoccerIndividualMatch(String title, int participants, MatchStatus status, User user, Team team) {
+		return Match.builder()
+			.title(title)
+			.sportsCategory(SportsCategory.SOCCER)
+			.matchType(MatchType.INDIVIDUAL_MATCH)
+			.matchDate(LocalDate.now())
+			.participants(participants)
+			.status(status)
+			.user(user)
+			.team(team)
+			.build();
+	}
+
+	private static Match getSoccerTeamMatch(String title, int participants, MatchStatus status, User user, Team team) {
+		return Match.builder()
+			.title(title)
+			.sportsCategory(SportsCategory.SOCCER)
+			.matchType(MatchType.TEAM_MATCH)
+			.matchDate(LocalDate.now())
+			.participants(participants)
+			.status(status)
+			.user(user)
+			.team(team)
+			.build();
+	}
+}


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-274] refactor: MatchProposalQueryDto 클래스 네이밍 변경](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/71c8c6e056a8d1e667daad5846ba82d6e1377674)
- MatchProposalQueryDto 네이밍 변경

### [[DK-274] feat: 리뷰 등록 API 구현](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/bab590bad2e95a385aba626e7076cfd5c9812a94)
- 리뷰에는 매칭 정보와 신청 정보가 전부 필요한데 이를 QueryDSL을 통해서 한번에 가져왔습니다.
- 상황은 테스트코드 보시면 아실듯...

### [[DK-274] test: 리뷰 등록 API 테스트 코드 작성](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/7951405026114282fbe183c32b35b11390ccd82a)
- 리뷰 등록 테스트 코드 작성

### [[DK-274] test: 매칭 신청 조회 (Giver) 테스트 코드 작성](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/e1ebd0cab16b6e039c04f53a671969a66ff73892)
- Giver에 있는 queryDSL 쿼리 메서드 테스트 코드 작성




[DK-274]: https://insta-kkyu.atlassian.net/browse/DK-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-274]: https://insta-kkyu.atlassian.net/browse/DK-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-274]: https://insta-kkyu.atlassian.net/browse/DK-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-274]: https://insta-kkyu.atlassian.net/browse/DK-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ