### PR TITLE
[Dk-325] 회원 가입 중복 체크 API 구현

### DIFF
--- a/src/main/java/com/kdt/team04/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kdt/team04/domain/auth/controller/AuthController.java
@@ -6,9 +6,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
-import org.springframework.boot.web.server.Cookie;
-import org.springframework.http.HttpCookie;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;

--- a/src/main/java/com/kdt/team04/domain/user/controller/UserController.java
+++ b/src/main/java/com/kdt/team04/domain/user/controller/UserController.java
@@ -9,7 +9,6 @@ import javax.validation.constraints.NotNull;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,7 +59,8 @@ public class UserController {
 	@Operation(summary = "회원 위치 정보 업데이트", description = "회원 위치 정보(위도, 경도)를 업데이트 한다.")
 	@PutMapping("/{id}/location")
 	public ApiResponse<UserResponse.UpdateLocationResponse> update(
-		@AuthenticationPrincipal JwtAuthentication auth, @RequestBody @Valid @NotNull UserRequest.UpdateLocationRequest request) {
+		@AuthenticationPrincipal JwtAuthentication auth,
+		@RequestBody @Valid @NotNull UserRequest.UpdateLocationRequest request) {
 		if (auth == null) {
 			throw new NotAuthenticationException("not authenticated");
 		}
@@ -68,5 +68,15 @@ public class UserController {
 		UserResponse.UpdateLocationResponse response = userService.updateLocation(auth.id(), request);
 
 		return new ApiResponse<>(response);
+	}
+
+	@GetMapping("/nickname/duplication")
+	public ApiResponse<Boolean> nicknameDuplicationCheck(@RequestParam String input) {
+		return new ApiResponse<>(userService.nicknameDuplicationCheck(input));
+	}
+
+	@GetMapping("/username/duplication")
+	public ApiResponse<Boolean> usernameDuplicationCheck(@RequestParam String input) {
+		return new ApiResponse<>(userService.usernameDuplicationCheck(input));
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/kdt/team04/domain/user/repository/UserRepository.java
@@ -11,4 +11,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByUsername(String username);
 
 	List<User> findByNicknameContaining(String nickname);
+
+	Boolean existsByNickname(String nickname);
+
+	Boolean existsByUsername(String username);
 }

--- a/src/main/java/com/kdt/team04/domain/user/service/UserService.java
+++ b/src/main/java/com/kdt/team04/domain/user/service/UserService.java
@@ -102,4 +102,12 @@ public class UserService {
 
 		return new UserResponse.UpdateLocationResponse(request.latitude(), request.longitude());
 	}
+
+	public Boolean usernameDuplicationCheck(String username) {
+		return userRepository.existsByUsername(username);
+	}
+
+	public Boolean nicknameDuplicationCheck(String nickname) {
+		return userRepository.existsByNickname(nickname);
+	}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,8 @@ security:
         - /v3/api-docs/**
         - /swagger-ui/**
         - /swagger-ui.html/**
+        - /api/users/nickname/duplication
+        - /api/users/username/duplication
       POST:
         - /api/users/signin
         - /api/users/signup

--- a/src/test/java/com/kdt/team04/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/kdt/team04/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,136 @@
+package com.kdt.team04.domain.user.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kdt.team04.common.ApiResponse;
+import com.kdt.team04.common.security.WebSecurityConfig;
+import com.kdt.team04.common.security.jwt.Jwt;
+import com.kdt.team04.domain.auth.service.TokenService;
+import com.kdt.team04.domain.user.service.UserService;
+
+@WebMvcTest({UserController.class, WebSecurityConfig.class})
+class UserControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@MockBean
+	UserService userService;
+
+	@MockBean
+	TokenService tokenService;
+
+	@MockBean
+	Jwt jwt;
+
+	@Test
+	@DisplayName("닉네임 중복시 true값 반환")
+	void testNicknameDuplicationCheckTrue() throws Exception {
+		//given
+		String duplicatedNickname = "test1234";
+		given(userService.nicknameDuplicationCheck(duplicatedNickname)).willReturn(true);
+
+		String response = objectMapper.writeValueAsString(new ApiResponse<>(true));
+
+		//when
+		ResultActions perform = mockMvc.perform(get("/api/users/nickname/duplication")
+			.param("input", duplicatedNickname)
+			.contentType(MediaType.APPLICATION_JSON)
+		).andDo(print());
+
+		//then
+		verify(userService, times(1)).nicknameDuplicationCheck(duplicatedNickname);
+
+		perform
+			.andExpect(status().isOk())
+			.andExpect(content().string(response));
+	}
+
+	@Test
+	@DisplayName("닉네임 중복아닐시 false값 반환")
+	void testNicknameDuplicationCheckFalse() throws Exception {
+		//given
+		String notDuplicatedNickname = "test1234";
+		given(userService.nicknameDuplicationCheck(notDuplicatedNickname)).willReturn(false);
+
+		String response = objectMapper.writeValueAsString(new ApiResponse<>(false));
+
+		//when
+		ResultActions perform = mockMvc.perform(get("/api/users/nickname/duplication")
+			.param("input", notDuplicatedNickname)
+			.contentType(MediaType.APPLICATION_JSON)
+		).andDo(print());
+
+		//then
+		verify(userService, times(1)).nicknameDuplicationCheck(notDuplicatedNickname);
+
+		perform
+			.andExpect(status().isOk())
+			.andExpect(content().string(response));
+	}
+
+	@Test
+	@DisplayName("유저네임 중복아닐시 false값 반환")
+	void testUsernameDuplicationCheckFalse() throws Exception {
+		//given
+		String notDuplicatedUsername = "test1234";
+		given(userService.usernameDuplicationCheck(notDuplicatedUsername)).willReturn(false);
+
+		String response = objectMapper.writeValueAsString(new ApiResponse<>(false));
+
+		//when
+		ResultActions perform = mockMvc.perform(get("/api/users/username/duplication")
+			.param("input", notDuplicatedUsername)
+			.contentType(MediaType.APPLICATION_JSON)
+		).andDo(print());
+
+		//then
+		verify(userService, times(1)).usernameDuplicationCheck(notDuplicatedUsername);
+
+		perform
+			.andExpect(status().isOk())
+			.andExpect(content().string(response));
+	}
+
+	@Test
+	@DisplayName("유저네임 중복 시 true값 반환")
+	void testUsernameDuplicationCheckTrue() throws Exception {
+		//given
+		String duplicatedUsername = "test1234";
+		given(userService.usernameDuplicationCheck(duplicatedUsername)).willReturn(true);
+
+		String response = objectMapper.writeValueAsString(new ApiResponse<>(true));
+
+		//when
+		ResultActions perform = mockMvc.perform(get("/api/users/username/duplication")
+			.param("input", duplicatedUsername)
+			.contentType(MediaType.APPLICATION_JSON)
+		).andDo(print());
+
+		//then
+		verify(userService, times(1)).usernameDuplicationCheck(duplicatedUsername);
+
+		perform
+			.andExpect(status().isOk())
+			.andExpect(content().string(response));
+	}
+}

--- a/src/test/java/com/kdt/team04/domain/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/user/service/UserServiceIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.kdt.team04.domain.user.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.persistence.EntityManager;
 
 import org.assertj.core.api.Assertions;
@@ -7,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.team04.domain.user.dto.UserRequest;
@@ -27,6 +30,9 @@ public class UserServiceIntegrationTest {
 
 	@Autowired
 	UserRepository userRepository;
+
+	@Autowired
+	PasswordEncoder passwordEncoder;
 
 	@Test
 	@DisplayName("새로운 유저는 위치정보가 처음엔 null이다.")
@@ -60,5 +66,89 @@ public class UserServiceIntegrationTest {
 		Assertions.assertThat(foundUser.getLocation().getLatitude()).isEqualTo(location.getLatitude());
 		Assertions.assertThat(response.latitude()).isEqualTo(location.getLatitude());
 		Assertions.assertThat(response.longitude()).isEqualTo(location.getLongitude());
+	}
+
+	@Test
+	@DisplayName("nickname이 중복되면 true를 반환한다.")
+	void testNicknameDuplicationCheckTrue() {
+		//given
+		String password = "@test1234!";
+		String encodedPassword = passwordEncoder.encode(password);
+
+		User userA = User.builder()
+			.username("test1234")
+			.nickname("nickname1234")
+			.password(encodedPassword)
+			.build();
+		entityManager.persist(userA);
+
+		//when
+		Boolean isDuplicated = userService.nicknameDuplicationCheck(userA.getNickname());
+
+		//then
+		assertThat(isDuplicated).isTrue();
+	}
+
+	@Test
+	@DisplayName("nickname이 중복되지 않으면 false를 반환한다.")
+	void testNicknameDuplicationCheckFalse() {
+		//given
+		String password = "@test1234!";
+		String encodedPassword = passwordEncoder.encode(password);
+
+		User userA = User.builder()
+			.username("test1234")
+			.nickname("nickname1235")
+			.password(encodedPassword)
+			.build();
+		entityManager.persist(userA);
+
+		//when
+		Boolean isDuplicated = userService.nicknameDuplicationCheck("nickname1234");
+
+		//then
+		assertThat(isDuplicated).isFalse();
+	}
+
+	@Test
+	@DisplayName("username이 중복되면 true를 반환한다.")
+	void testUsernameDuplicationCheckTrue() {
+		//given
+		String password = "@test1234!";
+		String encodedPassword = passwordEncoder.encode(password);
+
+		User userA = User.builder()
+			.username("test1234")
+			.nickname("nickname1234")
+			.password(encodedPassword)
+			.build();
+		entityManager.persist(userA);
+
+		//when
+		Boolean isDuplicated = userService.usernameDuplicationCheck(userA.getUsername());
+
+		//then
+		assertThat(isDuplicated).isTrue();
+	}
+
+	@Test
+	@DisplayName("username이 중복되지 않으면 false를 반환한다.")
+	void testUsernameDuplicationCheckFalse() {
+		//given
+		String password = "@test1234!";
+		String encodedPassword = passwordEncoder.encode(password);
+
+		User userA = User.builder()
+			.username("test1234")
+			.nickname("nickname1235")
+			.password(encodedPassword)
+			.build();
+		entityManager.persist(userA);
+
+		//when
+		Boolean isDuplicated = userService.usernameDuplicationCheck("test123456");
+
+		//then
+		assertThat(isDuplicated).isFalse();
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위

- [[DK-325] feat: nickname, username 중복체크 API 구현](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/8386dd9a3c34e418bd66dc1a0ef168bc24a8ad87)
  - 회원 가입 시 필요한 username, nickname 중복 체크 api를 만들었습니다.
 
  - end point
    - /api/users/nickname/duplication?input={?}
    - /api/users/username/duplication?input={?}

- [[DK-325] feat: nickname, username 중복체크 API 테스트 코드 작성](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/d43498c18140255a092998d4ed4dad24c551f521)
  - controller mockTest와 ServiceIntegrationTest를 작성했습니다.


## 🤔 고민 했던 부분

- 이 API들이 AuthController, AuthService에 들어가야할까, UserController UserService에 들어가야할까 고민이 됐었습니다.
  - AuthController에 들어가게 된다면 나중에 닉네임 변경 시 닉네임 중복체크 API를 AuthController에서 사용해야 하는데 쪼금 맞지 않다는 느낌이 들어 UserController, UserService에 넣게 되었습니다. 의견 주시면 감사하겠습니다!



## 🔊 HELP !!

- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

[DK-325]: https://insta-kkyu.atlassian.net/browse/DK-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-325]: https://insta-kkyu.atlassian.net/browse/DK-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ