### PR TITLE
[Dk-323]인증 로직 버그 수정

### DIFF
--- a/src/main/java/com/kdt/team04/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kdt/team04/common/security/jwt/JwtAuthenticationFilter.java
@@ -50,7 +50,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			authenticate(getAccessToken(request), request, response);
 		} catch (JwtTokenNotFoundException e) {
 			this.log.warn(e.getMessage());
-			refreshAuthentication(getAccessToken(request), request, response);
 		}
 		filterChain.doFilter(request, response);
 	}

--- a/src/main/java/com/kdt/team04/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kdt/team04/domain/auth/controller/AuthController.java
@@ -46,20 +46,22 @@ public class AuthController {
 		signInResponse.jwtAuthenticationToken().setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 		SecurityContextHolder.getContext().setAuthentication(signInResponse.jwtAuthenticationToken());
 
-		ResponseCookie accessTokenCookie = createSecureCookie(signInResponse.accessToken());
-		ResponseCookie refreshTokenCookie = createSecureCookie(signInResponse.refreshToken());
+		TokenDto accessToken = signInResponse.accessToken();
+		TokenDto refreshToken = signInResponse.refreshToken();
+		ResponseCookie accessTokenCookie = createSecureCookie(accessToken.header(), accessToken.token(), refreshToken.expirySecond());
+		ResponseCookie refreshTokenCookie = createSecureCookie(refreshToken.header(), refreshToken.token(), refreshToken.expirySecond());
 		response.setHeader(SET_COOKIE, accessTokenCookie.toString());
 		response.addHeader(SET_COOKIE, refreshTokenCookie.toString());
 
 		return new ApiResponse<>(signInResponse);
 	}
 
-	private ResponseCookie createSecureCookie(TokenDto tokenDto) {
-		return ResponseCookie.from(tokenDto.header(), tokenDto.token())
+	private ResponseCookie createSecureCookie(String header, String token, int expirySecond) {
+		return ResponseCookie.from(header, token)
 			.path("/")
 			.httpOnly(true)
 			.secure(true)
-			.maxAge(tokenDto.expirySecond())
+			.maxAge(expirySecond)
 			.sameSite("none")
 			.build();
 	}

--- a/src/main/java/com/kdt/team04/domain/auth/entity/Token.java
+++ b/src/main/java/com/kdt/team04/domain/auth/entity/Token.java
@@ -20,7 +20,7 @@ public class Token extends BaseEntity {
 		this.userId = userId;
 	}
 
-	public String token() {
+	public String getToken() {
 		return token;
 	}
 

--- a/src/main/java/com/kdt/team04/domain/auth/service/AuthService.java
+++ b/src/main/java/com/kdt/team04/domain/auth/service/AuthService.java
@@ -37,6 +37,7 @@ public class AuthService {
 		this.jwt = jwt;
 	}
 
+	@Transactional
 	public AuthResponse.SignInResponse signIn(String username, String password) {
 		UserResponse foundUser;
 		try {

--- a/src/main/java/com/kdt/team04/domain/auth/service/JpaTokenService.java
+++ b/src/main/java/com/kdt/team04/domain/auth/service/JpaTokenService.java
@@ -26,12 +26,12 @@ public class JpaTokenService implements TokenService {
 		Token foundToken = tokenRepository.findById(token).orElseThrow(() -> new EntityNotFoundException(
 			ErrorCode.TOKEN_NOT_FOUND, MessageFormat.format("Token = {0}", token)));
 
-		return new TokenResponse(foundToken.token(), foundToken.getUserId());
+		return new TokenResponse(foundToken.getToken(), foundToken.getUserId());
 	}
 
 	@Override
 	@Transactional
 	public String save(String refreshToken, Long userId) {
-		return this.tokenRepository.save(new Token(refreshToken, userId)).token();
+		return this.tokenRepository.save(new Token(refreshToken, userId)).getToken();
 	}
 }

--- a/src/test/java/com/kdt/team04/domain/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/user/controller/UserControllerIntegrationTest.java
@@ -14,10 +14,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.LongStream;
 
+import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.servlet.http.Cookie;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kdt.team04.common.ApiResponse;
+import com.kdt.team04.common.security.jwt.Jwt;
 import com.kdt.team04.domain.matches.match.entity.Match;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
 import com.kdt.team04.domain.matches.review.dto.MatchReviewResponse;
@@ -42,6 +46,7 @@ import com.kdt.team04.domain.security.WithMockJwtAuthentication;
 import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.teammember.entity.TeamMember;
+import com.kdt.team04.domain.user.Role;
 import com.kdt.team04.domain.user.dto.UserResponse;
 import com.kdt.team04.domain.user.entity.User;
 
@@ -58,12 +63,13 @@ class UserControllerIntegrationTest {
 	@PersistenceContext
 	private EntityManager entityManager;
 
+	@Autowired
+	Jwt jwt;
 	PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
 	@Test
 	@Transactional
 	@DisplayName("회원 프로필을 조회한다.")
-	@WithMockJwtAuthentication
 	void testFindProfile() throws Exception {
 		// given
 		User findUser = new User("test00", "nk-test00",
@@ -140,6 +146,7 @@ class UserControllerIntegrationTest {
 		ResultActions result = mockMvc.perform(
 			get("/api/users/" + findUser.getId())
 				.accept(MediaType.APPLICATION_JSON)
+				.cookie(getAccessTokenCookie(user))
 		);
 
 		// then
@@ -175,6 +182,7 @@ class UserControllerIntegrationTest {
 			get("/api/users")
 				.param("nickname", nickname)
 				.accept(MediaType.APPLICATION_JSON)
+				.cookie(getAccessTokenCookie(createUser(entityManager)))
 		);
 
 		// then
@@ -188,7 +196,6 @@ class UserControllerIntegrationTest {
 	@Test
 	@Transactional
 	@DisplayName("닉네임이 포함된 사용자가 없다면 비어있는 리스트를 반환한다.")
-	@WithMockJwtAuthentication
 	void testFindAllByNicknameEmpty() throws Exception {
 		// given
 		String nickname = "notfound";
@@ -207,6 +214,7 @@ class UserControllerIntegrationTest {
 			get("/api/users")
 				.param("nickname", nickname)
 				.accept(MediaType.APPLICATION_JSON)
+				.cookie(getAccessTokenCookie(createUser(entityManager)))
 		);
 
 		// then
@@ -220,7 +228,6 @@ class UserControllerIntegrationTest {
 	@Test
 	@Transactional
 	@DisplayName("닉네임이 null 혹은 빈값으로 요청된다면 예외를 반환한다.")
-	@WithMockJwtAuthentication
 	void testFindAllByNicknameException() throws Exception {
 		// given
 		LongStream.range(1, 6)
@@ -231,11 +238,32 @@ class UserControllerIntegrationTest {
 
 		// when
 		ResultActions result = mockMvc
-			.perform(get("/api/users"));
+			.perform(get("/api/users")
+				.cookie(getAccessTokenCookie(createUser(entityManager))));
 
 		// then
 		result.andDo(print())
 			.andExpect(status().isBadRequest());
 	}
 
+	User createUser(EntityManager entityManager) {
+		String encodedPassword = passwordEncoder.encode("@Test1234!");
+		User newUser = new User("dummyuser1234", "dummyNickname1",
+			encodedPassword);
+
+		entityManager.persist(newUser);
+
+		return newUser;
+	}
+
+	Cookie getAccessTokenCookie(User user) {
+		Jwt.Claims claims = Jwt.Claims.builder()
+			.userId(user.getId())
+			.roles(new String[] {String.valueOf(Role.USER)})
+			.username(user.getUsername())
+			.build();
+		String accessToken = jwt.generateAccessToken(claims);
+
+		return new Cookie(jwt.accessTokenProperties().header(), accessToken);
+	}
 }


### PR DESCRIPTION
## ✅  작업 단위

- [[DK-323] fix: 인증 로직 버그 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/7533df534cbaeafef300453c2416732b495b6f6e)
  - 토큰이 만료됐을시 쿠키가 삭제되어 액세스 토큰에 대한 정보가 없어 토큰을 재발급 받지 못하는 문제가 있었습니다
    - 액세스 토큰 쿠키 만료기한을 refreshToken과 똑같이 맞춰 액세스 토큰 쿠키가 refreshToken 쿠키 만료 전까지는 없어지지 않도록 했습니다.
      - 동운님 의견을 반영한 사항으로 토큰의 maxAge 꼭 설정을 하는게 보안상 좋겠다는 의견이었습니다.
    - 실제 액세스 토큰, 리프레쉬 토큰 만료시간은 각각 다르지만 토큰 쿠키의 만료시간은 리프레쉬토큰 기준인 것 입니다.
 

## 🤔 고민 했던 부분

- 액세스 토큰이없어도 리프레쉬 토큰이있다면 액세스 토큰을 발급받게 하는 것은 어떨까? 생각을 했었습니다.
  - 현재 재발급을 위해서는 기존의 만료된 토큰의 데이터를 이용해 재발급 받는 것인데 이것이 없다면 서버측에서 액세스 토큰을 가지고 있어야합니다.
  - Token 테이블에 accessToken 컬럼을 추가해 서버가 "최근 발급 액세스 토큰"을 저장할 수 있지만 JWT의 목적 중 하나인 서버 자원을 덜 쓰고자하는 목적이 퇴색될듯 하여 클라이언트가 액세스 토큰을 무조건 가지고 있어야 재발급 받을 수 있는 방식을 유지했습니다.

## 🔊 HELP !!


[DK-323]: https://insta-kkyu.atlassian.net/browse/DK-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ