### PR TITLE
[DK- 315] 팀 로고 이미지 업데이트 API 작성

### DIFF
--- a/src/main/java/com/kdt/team04/common/config/JasyptConfig.java
+++ b/src/main/java/com/kdt/team04/common/config/JasyptConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile({"dev","real"})
+@Profile({"local", "dev", "real"})
 public class JasyptConfig {
 
 	@Value("${encryptor.key}")

--- a/src/main/java/com/kdt/team04/common/file/ImagePath.java
+++ b/src/main/java/com/kdt/team04/common/file/ImagePath.java
@@ -1,7 +1,5 @@
 package com.kdt.team04.common.file;
 
-// https://sfam-bucket.s3.ap-northeast-2.amazonaws.com - prefix
-// users/profile/11f55110-9732-483a-b10a-bb7bcb7ba728.jpeg - key
 public enum ImagePath {
 	USERS_PROFILES("users/profile/"),
 	TEAMS_LOGO("teams/logo/");

--- a/src/main/java/com/kdt/team04/common/file/config/Aws.java
+++ b/src/main/java/com/kdt/team04/common/file/config/Aws.java
@@ -11,7 +11,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
-@Profile({"dev", "real"})
+@Profile({"local", "dev", "real"})
 @Configuration
 @EnableConfigurationProperties({AwsConfigProperties.class, S3ConfigProperties.class})
 public class Aws {

--- a/src/main/java/com/kdt/team04/common/file/config/AwsConfig.java
+++ b/src/main/java/com/kdt/team04/common/file/config/AwsConfig.java
@@ -14,11 +14,11 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 @Profile({"local", "dev", "real"})
 @Configuration
 @EnableConfigurationProperties({AwsConfigProperties.class, S3ConfigProperties.class})
-public class Aws {
+public class AwsConfig {
 
 	private final AwsConfigProperties awsConfigProperties;
 
-	public Aws(AwsConfigProperties awsConfigProperties) {
+	public AwsConfig(AwsConfigProperties awsConfigProperties) {
 		this.awsConfigProperties = awsConfigProperties;
 	}
 

--- a/src/main/java/com/kdt/team04/common/file/service/FileStorage.java
+++ b/src/main/java/com/kdt/team04/common/file/service/FileStorage.java
@@ -2,11 +2,11 @@ package com.kdt.team04.common.file.service;
 
 import org.springframework.core.io.Resource;
 
-import com.kdt.team04.common.file.ImagePath;
-
 public interface FileStorage {
 
-	String upload(Resource resource, ImagePath path);
+	String uploadByPath(Resource resource, String path);
+
+	void uploadByKey(Resource resource, String key);
 
 	void delete(String key);
 

--- a/src/main/java/com/kdt/team04/common/file/service/S3Uploader.java
+++ b/src/main/java/com/kdt/team04/common/file/service/S3Uploader.java
@@ -23,7 +23,7 @@ import com.kdt.team04.common.file.FileValidator;
 import com.kdt.team04.common.file.config.S3ConfigProperties;
 
 @Component
-@Profile({"dev", "real"})
+@Profile({"local", "dev", "real"})
 public class S3Uploader implements FileStorage {
 
 	@Qualifier(value = "amazonS3")

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchGiverService.java
@@ -48,7 +48,7 @@ public class MatchGiverService {
 		if (foundMatch.getMatchType() == MatchType.TEAM_MATCH) {
 			Team team = foundMatch.getTeam();
 			TeamResponse.SimpleResponse teamResponse = new TeamResponse.SimpleResponse(team.getId(), team.getName(),
-				team.getSportsCategory());
+				team.getSportsCategory(), team.getLogoImageUrl());
 
 			return matchConverter.toMatchResponse(foundMatch, authorResponse, teamResponse);
 		}
@@ -96,7 +96,7 @@ public class MatchGiverService {
 		if (foundMatch.getMatchType() == MatchType.TEAM_MATCH) {
 			Team team = foundMatch.getTeam();
 			TeamResponse.SimpleResponse teamResponse = new TeamResponse.SimpleResponse(team.getId(), team.getName(),
-				team.getSportsCategory());
+				team.getSportsCategory(), team.getLogoImageUrl());
 
 			return matchConverter.toMatchResponse(foundMatch, authorResponse, teamResponse);
 		}

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -144,7 +144,7 @@ public class MatchService {
 		if (foundMatch.getMatchType() == MatchType.TEAM_MATCH) {
 			Team team = foundMatch.getTeam();
 			TeamResponse.SimpleResponse teamResponse = new TeamResponse.SimpleResponse(team.getId(), team.getName(),
-				team.getSportsCategory());
+				team.getSportsCategory(), team.getLogoImageUrl());
 
 			return matchConverter.toMatchResponse(foundMatch, authorResponse, teamResponse);
 		}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalGiverService.java
@@ -87,7 +87,8 @@ public class MatchProposalGiverService {
 
 		if (matchProposal.getStatus() != MatchProposalStatus.APPROVED) {
 			throw new BusinessException(ErrorCode.PROPOSAL_NOT_APPROVED,
-				MessageFormat.format("proposerId = {0}, status = {1}", matchProposal.getId(), matchProposal.getStatus()));
+				MessageFormat.format("proposerId = {0}, status = {1}", matchProposal.getId(),
+					matchProposal.getStatus()));
 		}
 
 		matchProposal.updateStatus(MatchProposalStatus.FIXED);
@@ -97,7 +98,9 @@ public class MatchProposalGiverService {
 
 		Team team = matchProposal.getTeam();
 		TeamResponse.SimpleResponse teamResponse =
-			team == null ? null : new TeamResponse.SimpleResponse(team.getId(), team.getName(), team.getSportsCategory());
+			team == null ? null
+				: new TeamResponse.SimpleResponse(team.getId(), team.getName(),
+				team.getSportsCategory(), team.getLogoImageUrl());
 
 		return new MatchProposalResponse.FixedProposal(
 			matchProposal.getId(),

--- a/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
@@ -6,13 +6,18 @@ import javax.validation.Valid;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.google.common.net.MediaType;
 import com.kdt.team04.common.ApiResponse;
+import com.kdt.team04.common.exception.BusinessException;
+import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.common.exception.NotAuthenticationException;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.team.dto.TeamRequest;
@@ -65,4 +70,19 @@ public class TeamController {
 
 		return new ApiResponse<>(teams);
 	}
+
+	@Operation(summary = "팀 로고 이미지 업데이트", description = "로고 이미지 파일을 받아 팀 로고 이미지를 업데이트 합니다.")
+	@PatchMapping("/{id}/logo")
+	public void uploadLogo(@PathVariable Long id, @AuthenticationPrincipal JwtAuthentication auth, MultipartFile file) {
+		if (auth == null) {
+			throw new NotAuthenticationException("not authenticated");
+		}
+		if (file.isEmpty() || !file.getContentType().startsWith(MediaType.ANY_IMAGE_TYPE.type())) {
+			throw new BusinessException(ErrorCode.INVALID_FILE_TYPE,
+				"파일이 첨부되지 않았거나 지원하지 않는 타입입니다.");
+		}
+
+		teamService.uploadLogo(id, auth.id(), file);
+	}
+
 }

--- a/src/main/java/com/kdt/team04/domain/team/dto/TeamConverter.java
+++ b/src/main/java/com/kdt/team04/domain/team/dto/TeamConverter.java
@@ -30,6 +30,7 @@ public class TeamConverter {
 			.sportsCategory(team.getSportsCategory())
 			.description(team.getDescription())
 			.leader(leader)
+			.logoImageUrl(team.getLogoImageUrl())
 			.build();
 	}
 
@@ -44,6 +45,7 @@ public class TeamConverter {
 			.matchRecord(recordCount)
 			.matchReview(review)
 			.leader(leader)
+			.logoImageUrl(team.getLogoImageUrl())
 			.build();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/dto/TeamResponse.java
+++ b/src/main/java/com/kdt/team04/domain/team/dto/TeamResponse.java
@@ -35,7 +35,10 @@ public record TeamResponse(
 	MatchReviewResponse.TotalCount matchReview,
 
 	@Schema(description = "팀 리더 정보")
-	UserResponse leader
+	UserResponse leader,
+
+	@Schema(description = "팀 로고 이미지 url")
+	String logoImageUrl
 ) {
 
 	public record SimpleResponse(
@@ -46,6 +49,10 @@ public record TeamResponse(
 		String name,
 
 		@Schema(description = "스포츠 종목")
-		SportsCategory sportsCategory
-	) { }
+		SportsCategory sportsCategory,
+
+		@Schema(description = "팀 로고 이미지 url")
+		String logoImageUrl
+	) {
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/entity/Team.java
+++ b/src/main/java/com/kdt/team04/domain/team/entity/Team.java
@@ -42,16 +42,24 @@ public class Team extends BaseEntity {
 	@JoinColumn(name = "leader_id")
 	private User leader;
 
+	private String logoImageUrl;
+
 	protected Team() {
 	}
 
 	@Builder
-	public Team(Long id, String name, String description, SportsCategory sportsCategory, User leader) {
+	public Team(Long id, String name, String description, SportsCategory sportsCategory,
+		User leader, String logoImageUrl) {
 		this.id = id;
 		this.name = name;
 		this.description = description;
 		this.sportsCategory = sportsCategory;
 		this.leader = leader;
+		this.logoImageUrl = logoImageUrl;
+	}
+
+	public void updateLogoUrl(String logoImageUrl) {
+		this.logoImageUrl = logoImageUrl;
 	}
 
 	public Long getId() {
@@ -73,4 +81,9 @@ public class Team extends BaseEntity {
 	public User getLeader() {
 		return leader;
 	}
+
+	public String getLogoImageUrl() {
+		return logoImageUrl;
+	}
+
 }

--- a/src/main/java/com/kdt/team04/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/kdt/team04/domain/team/repository/TeamRepository.java
@@ -1,6 +1,7 @@
 package com.kdt.team04.domain.team.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,5 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 	@Query("SELECT t FROM Team t INNER JOIN TeamMember tm ON t.id = tm.team.id WHERE tm.user.id = :userId")
 	List<Team> findAllByTeamMemberUserId(@Param("userId") Long userId);
 
+	Optional<Team> findByIdAndLeaderId(Long id, Long leaderId);
 }

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamGiverService.java
@@ -43,7 +43,7 @@ public class TeamGiverService {
 	public List<TeamResponse.SimpleResponse> findAllByTeamMemberUserId(Long userId) {
 		return teamRepository.findAllByTeamMemberUserId(userId).stream()
 			.map(team -> new TeamResponse.SimpleResponse(
-					team.getId(), team.getName(), team.getSportsCategory()
+					team.getId(), team.getName(), team.getSportsCategory(), team.getLogoImageUrl()
 				)
 			).toList();
 	}

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
@@ -5,9 +5,12 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.kdt.team04.common.exception.EntityNotFoundException;
 import com.kdt.team04.common.exception.ErrorCode;
+import com.kdt.team04.common.file.ImagePath;
+import com.kdt.team04.common.file.service.S3Uploader;
 import com.kdt.team04.domain.matches.review.dto.MatchRecordResponse;
 import com.kdt.team04.domain.matches.review.dto.MatchReviewResponse;
 import com.kdt.team04.domain.matches.review.service.MatchRecordGiverService;
@@ -35,11 +38,12 @@ public class TeamService {
 	private final TeamMemberGiverService teamMemberGiver;
 	private final MatchRecordGiverService matchRecordGiver;
 	private final MatchReviewGiverService matchReviewGiver;
+	private final S3Uploader s3Uploader;
 
 	public TeamService(TeamRepository teamRepository, TeamConverter teamConverter, UserConverter userConverter,
 		UserService userService,
 		TeamMemberGiverService teamMemberGiver, MatchRecordGiverService matchRecordGiver,
-		MatchReviewGiverService matchReviewGiver) {
+		MatchReviewGiverService matchReviewGiver, S3Uploader s3Uploader) {
 		this.teamRepository = teamRepository;
 		this.teamConverter = teamConverter;
 		this.userConverter = userConverter;
@@ -47,6 +51,7 @@ public class TeamService {
 		this.teamMemberGiver = teamMemberGiver;
 		this.matchRecordGiver = matchRecordGiver;
 		this.matchReviewGiver = matchReviewGiver;
+		this.s3Uploader = s3Uploader;
 	}
 
 	@Transactional
@@ -83,7 +88,24 @@ public class TeamService {
 				new TeamResponse.SimpleResponse(
 					team.getId(),
 					team.getName(),
-					team.getSportsCategory()))
+					team.getSportsCategory(),
+					team.getLogoImageUrl()))
 			.toList();
 	}
+
+	@Transactional
+	public void uploadLogo(Long teamId, Long leaderId, MultipartFile file) {
+		Team team = teamRepository.findByIdAndLeaderId(teamId, leaderId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_TEAM_LEADER,
+				MessageFormat.format("TeamId = {0}", teamId)));
+
+		if (team.getLogoImageUrl() != null) {
+			s3Uploader.delete(team.getLogoImageUrl());
+		}
+
+		String key = s3Uploader.upload(file.getResource(), ImagePath.TEAMS_LOGO);
+
+		team.updateLogoUrl(key);
+	}
+
 }

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
@@ -2,6 +2,7 @@ package com.kdt.team04.domain.team.service;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,13 +100,14 @@ public class TeamService {
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.NOT_TEAM_LEADER,
 				MessageFormat.format("TeamId = {0}", teamId)));
 
-		if (team.getLogoImageUrl() != null) {
-			s3Uploader.delete(team.getLogoImageUrl());
-		}
-
-		String key = s3Uploader.upload(file.getResource(), ImagePath.TEAMS_LOGO);
-
-		team.updateLogoUrl(key);
+		Optional.ofNullable(team.getLogoImageUrl())
+			.ifPresentOrElse(
+				key -> s3Uploader.uploadByKey(file.getResource(), key),
+				() -> {
+					String key = s3Uploader.uploadByPath(file.getResource(), ImagePath.TEAMS_LOGO.getPath());
+					team.updateLogoUrl(key);
+				}
+			);
 	}
 
 }

--- a/src/main/java/com/kdt/team04/domain/user/service/UserService.java
+++ b/src/main/java/com/kdt/team04/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.kdt.team04.domain.user.service;
 
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -126,13 +127,14 @@ public class UserService {
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND,
 				MessageFormat.format("UserId = {0}", id)));
 
-		if (foundUser.getProfileImageUrl() != null) {
-			s3Uploader.delete(foundUser.getProfileImageUrl());
-		}
-
-		String key = s3Uploader.upload(file.getResource(), ImagePath.USERS_PROFILES);
-
-		foundUser.updateImageUrl(key);
+		Optional.ofNullable(foundUser.getProfileImageUrl())
+			.ifPresentOrElse(
+				key -> s3Uploader.uploadByKey(file.getResource(), key),
+				() -> {
+					String key = s3Uploader.uploadByPath(file.getResource(), ImagePath.USERS_PROFILES.getPath());
+					foundUser.updateImageUrl(key);
+				}
+			);
 	}
 
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -15,3 +15,18 @@ logging:
     org.hibernate.type.descriptor.sql: DEBUG
 jwt:
   client-secret: ${JWT_SECRET:DEFAULT_JWT_SECRET}
+
+cloud:
+  aws:
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY:ENC(DJZaeqCiNozKW4JuuBSKP5bL5RG4N96dO0cBIutH6po=)}
+      secretKey: ${AWS_SECRET_KEY:ENC(kBszTKJdX9T5msgT1OTUiRjKcTngLRG8bYYL4FGfUK3xq7fO6WRQBMTUEXehXtZHeEFWHbvAmEw=)}
+    s3:
+      bucket: ${S3_BUCKET:ENC(IDNhmo1D2i5p8+FnBMUzU/BLYyxnfKNx)}
+      url: ${S3_URL:ENC(Ol+MZICacLWE4oltu+sYOwNARkwWjfwA50g+5i0FyYOYCcjuRe9/I9AoHHczVNB13pjcbtnaBn+12zqsDPmIKw==)}
+    stack:
+      auto: false
+    region: ${AWS_REGION:ENC(ayPRiqCMtSXBerKcGgVo29E2r606Z1Ht)}
+
+encryptor:
+  key: ${ENCRYPTOR_KEY}

--- a/src/main/resources/db/migration/V5_2__Alter_teams_add_colunm_image_url.sql
+++ b/src/main/resources/db/migration/V5_2__Alter_teams_add_colunm_image_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE team ADD logo_image_url VARCHAR(500);

--- a/src/test/java/com/kdt/team04/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/team/service/TeamServiceTest.java
@@ -68,12 +68,12 @@ class TeamServiceTest {
 	private final TeamRequest.CreateRequest CREATE_REQUEST = new TeamRequest.CreateRequest("team1", "first team",
 		SportsCategory.BADMINTON);
 	private final Team TEAM = new Team(10L, CREATE_REQUEST.name(), CREATE_REQUEST.description(),
-		CREATE_REQUEST.sportsCategory(), USER);
+		CREATE_REQUEST.sportsCategory(), USER, null);
 	private final MatchRecordResponse.TotalCount RECORD = new MatchRecordResponse.TotalCount(1, 1, 1);
 	private final MatchReviewResponse.TotalCount REVIEW = new MatchReviewResponse.TotalCount(1, 1, 1);
 	private final TeamResponse RESPONSE = new TeamResponse(TEAM.getId(), TEAM.getName(), TEAM.getDescription(),
 		TEAM.getSportsCategory(),
-		Collections.emptyList(), RECORD, REVIEW, USER_RESPONSE);
+		Collections.emptyList(), RECORD, REVIEW, USER_RESPONSE, null);
 
 	@Test
 	@DisplayName("팀 생성에 성공합니다.")

--- a/src/test/java/com/kdt/team04/domain/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/user/controller/UserControllerIntegrationTest.java
@@ -142,9 +142,9 @@ class UserControllerIntegrationTest {
 		MatchReviewResponse.TotalCount reviewResponse = new MatchReviewResponse.TotalCount(1, 0, 0);
 		List<TeamResponse.SimpleResponse> teamResponses = Arrays.asList(
 			new TeamResponse.SimpleResponse(findUserTeam1.getId(), findUserTeam1.getName(),
-				findUserTeam1.getSportsCategory()),
+				findUserTeam1.getSportsCategory(), findUserTeam1.getLogoImageUrl()),
 			new TeamResponse.SimpleResponse(findUserTeam2.getId(), findUserTeam2.getName(),
-				findUserTeam2.getSportsCategory())
+				findUserTeam2.getSportsCategory(), findUserTeam2.getLogoImageUrl())
 		);
 		UserResponse.FindProfile profileResponse = new UserResponse.FindProfile(findUser.getNickname(),  findUser.getProfileImageUrl(), reviewResponse,
 			teamResponses);

--- a/src/test/java/com/kdt/team04/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/user/service/UserServiceTest.java
@@ -122,8 +122,8 @@ class UserServiceTest {
 
 		MatchReviewResponse.TotalCount review = new MatchReviewResponse.TotalCount(1, 1, 1);
 		List<TeamResponse.SimpleResponse> teams = Arrays.asList(
-			new TeamResponse.SimpleResponse(1L, "축구왕", SportsCategory.SOCCER),
-			new TeamResponse.SimpleResponse(2L, "야구왕", SportsCategory.BASEBALL)
+			new TeamResponse.SimpleResponse(1L, "축구왕", SportsCategory.SOCCER, null),
+			new TeamResponse.SimpleResponse(2L, "야구왕", SportsCategory.BASEBALL, null)
 		);
 		UserResponse.FindProfile response = new UserResponse.FindProfile(user.getUsername(), user.getProfileImageUrl(),
 			review, teams);


### PR DESCRIPTION
## ✅  작업 단위

- 기존에 만들어둔 파일 업로더를 이용하여 팀 로고 이미지 업데이트 API도 추가했습니다. 

* 기존에 이미지 경로가 있다면 지우는 작업을 진행 후 업로드를 하는 코드로 작성되어 있었는데, 진형님께서 덮어 씌워진다는 피드백을 주셔서 다시 수정을 진행했습니다.
* S3는 유틸성이 강한 클래스이기 때문에 비즈니스 로직에 관련된 정보를 받아서는 안된다는 피드백도 받아 ImagePath를 파라미터로 받은 부분을 String path로 변경했습니다.
* 기존에 이미지가 있을 경우와 없을 경우를 나눠서 uploadByPath, uploadByKey라는 메서드로 분리를 해서 진행했는데 더 나은 방법이나 네이밍이 있다면 추천해 주시면 감사드리겠습니다 :) 
  * 오버로딩을 고려하지 않은 이유는 이펙티브 자바 아이템 52의 다중정의는 신중히 사용하라 부분을 참고해서 오버로딩은 사용하지 않는 방향으로 생각했습니다 !

## 🤔 고민 했던 부분

## 🔊 HELP !!
