### PR TITLE
[DK-347] 사용자가 팀을 생성할 수 있다 [스토리 리팩터링]

### DIFF
--- a/src/main/java/com/kdt/team04/domain/BaseEntity.java
+++ b/src/main/java/com/kdt/team04/domain/BaseEntity.java
@@ -6,6 +6,8 @@ import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -46,4 +48,13 @@ public abstract class BaseEntity {
 		return updatedBy;
 	}
 
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("createdAt", createdAt)
+			.append("updatedAt", updatedAt)
+			.append("createdBy", createdBy)
+			.append("updatedBy", updatedBy)
+			.toString();
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kdt/team04/domain/team/controller/TeamController.java
@@ -36,13 +36,12 @@ public class TeamController {
 	@Operation(summary = "팀을 생성한다.", description = "새로운 팀을 생성할 수 있습니다.")
 	@PostMapping
 	public void create(@AuthenticationPrincipal JwtAuthentication jwtAuthentication,
-		@RequestBody @Valid TeamRequest.CreateRequest request) {
+		@RequestBody @Valid TeamRequest.CreateRequest requestDto) {
 		if (jwtAuthentication == null) {
 			throw new NotAuthenticationException("Not Authenticated");
 		}
 
-		teamService.create(jwtAuthentication.id(), request.name(), request.sportsCategory(),
-			request.description());
+		teamService.create(jwtAuthentication.id(),requestDto);
 	}
 
 	@Operation(summary = "팀 프로필 조회", description = "해당 id의 팀 프로필을 조회할 수 있습니다.")

--- a/src/main/java/com/kdt/team04/domain/team/entity/Team.java
+++ b/src/main/java/com/kdt/team04/domain/team/entity/Team.java
@@ -13,6 +13,9 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import com.kdt.team04.domain.BaseEntity;
 import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.user.entity.User;
@@ -38,8 +41,9 @@ public class Team extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	private SportsCategory sportsCategory;
 
+	@NotNull
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "leader_id")
+	@JoinColumn(name = "leader_id", nullable = false)
 	private User leader;
 
 	protected Team() {
@@ -72,5 +76,17 @@ public class Team extends BaseEntity {
 
 	public User getLeader() {
 		return leader;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("id", id)
+			.append("name", name)
+			.append("description", description)
+			.append("sportsCategory", sportsCategory)
+			.append("leader", leader)
+			.append("baseEntity",super.toString())
+			.toString();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
+++ b/src/main/java/com/kdt/team04/domain/team/service/TeamService.java
@@ -12,8 +12,8 @@ import com.kdt.team04.domain.matches.review.dto.MatchRecordResponse;
 import com.kdt.team04.domain.matches.review.dto.MatchReviewResponse;
 import com.kdt.team04.domain.matches.review.service.MatchRecordGiverService;
 import com.kdt.team04.domain.matches.review.service.MatchReviewGiverService;
-import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.team.dto.TeamConverter;
+import com.kdt.team04.domain.team.dto.TeamRequest;
 import com.kdt.team04.domain.team.dto.TeamResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.team.repository.TeamRepository;
@@ -50,15 +50,16 @@ public class TeamService {
 	}
 
 	@Transactional
-	public Long create(Long userId, String teamName, SportsCategory sportsCategory, String description) {
+	public Long create(Long userId, TeamRequest.CreateRequest requestDto) {
 		User user = userConverter.toUser(userService.findById(userId));
 		Team savedTeam = teamRepository.save(
 			Team.builder()
-				.name(teamName)
-				.sportsCategory(sportsCategory)
-				.description(description)
+				.name(requestDto.name())
+				.sportsCategory(requestDto.sportsCategory())
+				.description(requestDto.description())
 				.leader(user)
-				.build());
+				.build()
+		);
 		teamMemberGiver.registerTeamLeader(savedTeam.getId(), user.getId());
 
 		return savedTeam.getId();

--- a/src/main/java/com/kdt/team04/domain/user/UserConverter.java
+++ b/src/main/java/com/kdt/team04/domain/user/UserConverter.java
@@ -13,7 +13,7 @@ public class UserConverter {
 			.id(userResponse.id())
 			.username(userResponse.username())
 			.nickname(userResponse.nickname())
-			.location(userResponse.Location())
+			.location(userResponse.location())
 			.build();
 	}
 
@@ -23,7 +23,7 @@ public class UserConverter {
 			.username(user.getUsername())
 			.nickname(user.getNickname())
 			.location(user.getLocation())
-			.ProfileImageUr(user.getProfileImageUrl())
+			.profileImageUrl(user.getProfileImageUrl())
 			.build();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/user/UserConverter.java
+++ b/src/main/java/com/kdt/team04/domain/user/UserConverter.java
@@ -9,12 +9,20 @@ import com.kdt.team04.domain.user.entity.User;
 public class UserConverter {
 
 	public User toUser(UserResponse userResponse) {
-		return new User(userResponse.id(), userResponse.password(), userResponse.username(), userResponse.nickname(),
-			userResponse.location());
+		return User.builder()
+			.id(userResponse.id())
+			.username(userResponse.username())
+			.nickname(userResponse.nickname())
+			.location(userResponse.location())
+			.build();
 	}
 
 	public UserResponse toUserResponse(User user) {
-		return new UserResponse(user.getId(), user.getUsername(), user.getPassword(), user.getNickname(),
-			user.getLocation());
+		return UserResponse.builder()
+			.id(user.getId())
+			.username(user.getUsername())
+			.nickname(user.getNickname())
+			.location(user.getLocation())
+			.build();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/kdt/team04/domain/user/dto/UserResponse.java
@@ -15,7 +15,7 @@ public record UserResponse(
 	String username,
 	String password,
 	String nickname,
-	Location location
+	Location location,
 	String profileImageUrl
 ) {
 

--- a/src/main/java/com/kdt/team04/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/kdt/team04/domain/user/dto/UserResponse.java
@@ -9,13 +9,13 @@ import com.kdt.team04.domain.user.entity.Location;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+@Builder
 public record UserResponse(
 	Long id,
 	String username,
 	String password,
 	String nickname,
 	Location location
-
 ) {
 
 	@Builder

--- a/src/main/java/com/kdt/team04/domain/user/entity/User.java
+++ b/src/main/java/com/kdt/team04/domain/user/entity/User.java
@@ -10,6 +10,9 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import com.kdt.team04.domain.BaseEntity;
 
 import lombok.Builder;
@@ -77,5 +80,15 @@ public class User extends BaseEntity {
 
 	public void updateLocation(Location location) {
 		this.location = location;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("id", id)
+			.append("username", username)
+			.append("nickname", nickname)
+			.append("location", location)
+			.toString();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/user/service/UserService.java
+++ b/src/main/java/com/kdt/team04/domain/user/service/UserService.java
@@ -38,13 +38,13 @@ public class UserService {
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND,
 				MessageFormat.format("Username = {0}", username)));
 
-		return new UserResponse(
-			foundUser.getId(),
-			foundUser.getUsername(),
-			foundUser.getPassword(),
-			foundUser.getNickname(),
-			foundUser.getLocation()
-		);
+		return UserResponse.builder()
+			.id(foundUser.getId())
+			.username(foundUser.getUsername())
+			.password(foundUser.getPassword())
+			.nickname(foundUser.getNickname())
+			.location(foundUser.getLocation())
+			.build();
 	}
 
 	@Transactional
@@ -84,13 +84,12 @@ public class UserService {
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND,
 				MessageFormat.format("UserId = {0}", id)));
 
-		return new UserResponse(
-			foundUser.getId(),
-			foundUser.getUsername(),
-			foundUser.getPassword(),
-			foundUser.getNickname(),
-			foundUser.getLocation()
-		);
+		return UserResponse.builder()
+			.id(foundUser.getId())
+			.username(foundUser.getUsername())
+			.nickname(foundUser.getNickname())
+			.location(foundUser.getLocation())
+			.build();
 	}
 
 	@Transactional

--- a/src/test/java/com/kdt/team04/configure/JpaAuditConfig.java
+++ b/src/test/java/com/kdt/team04/configure/JpaAuditConfig.java
@@ -1,0 +1,36 @@
+package com.kdt.team04.configure;
+
+import java.util.Optional;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.kdt.team04.common.security.jwt.JwtAuthentication;
+
+@TestConfiguration
+public class JpaAuditConfig {
+	@TestConfiguration
+	@EnableJpaAuditing
+	public class TestJpaAuditConfig {
+
+		@Bean
+		public AuditorAware<String> autAuditorProvider() {
+			return () -> {
+				Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+				if (authentication == null || !authentication.isAuthenticated()) {
+					return Optional.empty();
+				}
+
+				JwtAuthentication user = (JwtAuthentication)authentication.getPrincipal();
+
+				return Optional.of(user.id().toString());
+			};
+		}
+	}
+
+}

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
@@ -84,28 +84,35 @@ class MatchProposalServiceIntegrationTest {
 	void testTeamProposerCreateSuccess() {
 		//given
 		User author = new User("author", "author", "aA1234!");
+
+		entityManager.persist(author);
+
 		Team authorTeam = Team.builder()
 			.name("team1")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(author)
 			.build();
+
 		entityManager.persist(authorTeam);
-		entityManager.persist(author);
 
 		User proposer = new User("proposer", "proposer", "aA1234!");
 		User user1 = new User("member1", "member1", "password");
 		User user2 = new User("member2", "member2", "password");
+
 		entityManager.persist(proposer);
 		entityManager.persist(user1);
 		entityManager.persist(user2);
+
 		proposer.updateLocation(new Location(1.1, 1.2));
+
 		Team proposerTeam = Team.builder()
 			.name("team1")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
 			.build();
+
 		entityManager.persist(proposerTeam);
 		entityManager.persist(new TeamMember(proposerTeam, user1, TeamMemberRole.LEADER));
 		entityManager.persist(new TeamMember(proposerTeam, user1, TeamMemberRole.MEMBER));
@@ -122,7 +129,9 @@ class MatchProposalServiceIntegrationTest {
 			.sportsCategory(SportsCategory.BADMINTON)
 			.content("content")
 			.build();
+
 		entityManager.persist(match);
+
 		MatchProposalRequest.ProposalCreate request = new MatchProposalRequest.ProposalCreate(proposerTeam.getId(),
 			"팀전 신청합니다.");
 
@@ -138,17 +147,23 @@ class MatchProposalServiceIntegrationTest {
 	void testTeamProposerCreateFailByTeamMember() {
 		//given
 		User author = new User("author", "author", "aA1234!");
+
+		entityManager.persist(author);
+
 		Team authorTeam = Team.builder()
 			.name("team1")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(author)
 			.build();
+
 		entityManager.persist(authorTeam);
 		entityManager.persist(author);
 
 		User proposer = new User("proposer", "proposer", "aA1234!");
+
 		entityManager.persist(proposer);
+
 		proposer.updateLocation(new Location(1.1, 1.2));
 		Team proposerTeam = Team.builder()
 			.name("team1")
@@ -156,6 +171,7 @@ class MatchProposalServiceIntegrationTest {
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
 			.build();
+
 		entityManager.persist(proposerTeam);
 
 		Match match = Match.builder()
@@ -169,7 +185,9 @@ class MatchProposalServiceIntegrationTest {
 			.sportsCategory(SportsCategory.BADMINTON)
 			.content("content")
 			.build();
+
 		entityManager.persist(match);
+
 		MatchProposalRequest.ProposalCreate request = new MatchProposalRequest.ProposalCreate(proposerTeam.getId(),
 			"팀전 신청합니다.");
 
@@ -184,6 +202,10 @@ class MatchProposalServiceIntegrationTest {
 		//given
 		User author = new User("author", "author", "aA1234!");
 		User proposer = new User("proposer", "proposer", "aA1234!");
+
+		entityManager.persist(author);
+		entityManager.persist(proposer);
+
 		Team authorTeam = Team.builder()
 			.name("team1")
 			.description("first team")
@@ -196,10 +218,9 @@ class MatchProposalServiceIntegrationTest {
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
 			.build();
+
 		entityManager.persist(authorTeam);
 		entityManager.persist(proposerTeam);
-		entityManager.persist(author);
-		entityManager.persist(proposer);
 
 		Match match = Match.builder()
 			.title("match")

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
@@ -38,6 +38,7 @@ class MatchProposalServiceIntegrationTest {
 		//given
 		User author = new User("author", "author", "aA1234!");
 		User proposer = new User("proposer", "proposer", "aA1234!");
+
 		entityManager.persist(author);
 		entityManager.persist(proposer);
 
@@ -51,7 +52,9 @@ class MatchProposalServiceIntegrationTest {
 			.sportsCategory(SportsCategory.BADMINTON)
 			.content("content")
 			.build();
+
 		entityManager.persist(match);
+
 		MatchProposalRequest.ProposalCreate request = new MatchProposalRequest.ProposalCreate(null, "개인전 신청합니다.");
 
 		//when
@@ -67,6 +70,10 @@ class MatchProposalServiceIntegrationTest {
 		//given
 		User author = new User("author", "author", "aA1234!");
 		User proposer = new User("proposer", "proposer", "aA1234!");
+
+		entityManager.persist(author);
+		entityManager.persist(proposer);
+
 		Team authorTeam = Team.builder()
 			.name("team1")
 			.description("first team")
@@ -79,6 +86,7 @@ class MatchProposalServiceIntegrationTest {
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
 			.build();
+
 		entityManager.persist(authorTeam);
 		entityManager.persist(proposerTeam);
 		entityManager.persist(author);
@@ -112,6 +120,10 @@ class MatchProposalServiceIntegrationTest {
 		//given
 		User author = new User("author", "author", "aA1234!");
 		User proposer = new User("proposer", "proposer", "aA1234!");
+
+		entityManager.persist(author);
+		entityManager.persist(proposer);
+
 		Team authorTeam = Team.builder()
 			.name("team1")
 			.description("first team")
@@ -124,6 +136,7 @@ class MatchProposalServiceIntegrationTest {
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
 			.build();
+
 		entityManager.persist(authorTeam);
 		entityManager.persist(proposerTeam);
 		entityManager.persist(author);

--- a/src/test/java/com/kdt/team04/domain/team/entity/TeamValidationTest.java
+++ b/src/test/java/com/kdt/team04/domain/team/entity/TeamValidationTest.java
@@ -1,0 +1,111 @@
+package com.kdt.team04.domain.team.entity;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.validation.ConstraintViolationException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import com.kdt.team04.configure.TestQueryDslConfig;
+import com.kdt.team04.domain.team.SportsCategory;
+import com.kdt.team04.domain.team.repository.TeamRepository;
+import com.kdt.team04.domain.user.entity.User;
+
+@Import(TestQueryDslConfig.class)
+@DataJpaTest
+public class TeamValidationTest {
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Test
+	@DisplayName("팀 이름이 2글자 미만이거나 10글자 보다 크면 validation 예외가 발생한다.[공백 및 공백으로 이루어진 문자열 포함]")
+	void testTeamNameViolation() {
+		//given
+
+		List<String> violations = List.of("", "꿀", " ", "일이삼사오육칠팔구십초과");
+		User teamCreator = getTeamCreator();
+
+		violations.forEach(violation -> {
+			Team newTeam = Team.builder()
+				.name(violation)
+				.description("이하 생략")
+				.sportsCategory(SportsCategory.SOCCER)
+				.leader(teamCreator)
+				.build();
+
+			//when
+			//then
+			assertThatThrownBy(() -> teamRepository.save(newTeam))
+				.isInstanceOf(ConstraintViolationException.class);
+		});
+	}
+
+	@Test
+	@DisplayName("팀 설명이 100글자를 넘어가면 validation 예외가 발생한다.[공백 및 공백으로 이루어진 문자열 포함]")
+	void testDescriptionGrater100() {
+		//given
+		User teamCreator = getTeamCreator();
+		String violationLetters = create101Letters();
+		List<String> violations = List.of("", " ", violationLetters);
+
+		violations.forEach(violation -> {
+			Team newTeam = Team.builder()
+				.name("꿀꿀꿀")
+				.description(violation)
+				.sportsCategory(SportsCategory.BADMINTON)
+				.leader(teamCreator)
+				.build();
+
+			//when
+			//then
+			assertThatThrownBy(() -> teamRepository.save(newTeam))
+				.isInstanceOf(ConstraintViolationException.class);
+		});
+	}
+
+	@Test
+	@DisplayName("팀 리더 없이 팀을 생성하면 validation 예외가 발생한다")
+	void testNotContainLeader() {
+		//given
+		Team newTeam = Team.builder()
+			.name("꿀꿀꿀")
+			.description("이하 생략.")
+			.sportsCategory(SportsCategory.SOCCER)
+			.build();
+
+		//when
+		//then
+		assertThatThrownBy(() -> teamRepository.save(newTeam))
+			.isInstanceOf(ConstraintViolationException.class);
+	}
+
+	private String create101Letters() {
+		StringBuilder builder = new StringBuilder();
+
+		Stream.generate(() -> 0)
+			.limit(101)
+			.forEach(builder::append);
+
+		return builder.toString();
+	}
+
+	public User getTeamCreator() {
+		return entityManager.persist(User.builder()
+			.username("test1234")
+			.nickname("nickname")
+			.password("Test1234!!")
+			.build());
+	}
+}

--- a/src/test/java/com/kdt/team04/domain/team/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/kdt/team04/domain/team/repository/TeamRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.kdt.team04.domain.team.repository;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import com.kdt.team04.common.config.QueryDslConfig;
+import com.kdt.team04.configure.JpaAuditConfig;
+import com.kdt.team04.domain.team.SportsCategory;
+import com.kdt.team04.domain.team.entity.Team;
+import com.kdt.team04.domain.user.entity.User;
+
+@Import({QueryDslConfig.class, JpaAuditConfig.class})
+@DataJpaTest
+class TeamRepositoryTest {
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Autowired
+	private TeamRepository teamRepository;
+
+	@Test
+	@DisplayName("팀을 생성한다")
+	void testSave() {
+		//given
+		User teamCreator = getTeamCreator();
+		Team newTeam = Team.builder()
+			.name("가보자고!")
+			.description("이하 생략")
+			.sportsCategory(SportsCategory.SOCCER)
+			.leader(teamCreator)
+			.build();
+
+		//when
+		Team createdTeam = teamRepository.save(newTeam);
+		System.out.println("dasd : " + createdTeam);
+
+		//then
+		Assertions.assertThat(createdTeam.getName()).isEqualTo(newTeam.getName());
+		Assertions.assertThat(createdTeam.getDescription()).isEqualTo(newTeam.getDescription());
+		Assertions.assertThat(createdTeam.getSportsCategory()).isEqualTo(newTeam.getSportsCategory());
+		Assertions.assertThat(createdTeam.getCreatedAt().getMinute()).isEqualTo(LocalDateTime.now().getMinute());
+	}
+
+	public User getTeamCreator() {
+		return entityManager.persist(User.builder()
+			.username("test1234")
+			.nickname("nickname")
+			.password("Test1234!!")
+			.build());
+	}
+
+}

--- a/src/test/java/com/kdt/team04/domain/team/service/TeamServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/team/service/TeamServiceIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.kdt.team04.common.exception.EntityNotFoundException;
+import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.common.file.service.S3Uploader;
 import com.kdt.team04.domain.team.dto.TeamRequest;

--- a/src/test/java/com/kdt/team04/domain/team/service/TeamServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/team/service/TeamServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.kdt.team04.domain.team.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.team04.common.exception.EntityNotFoundException;
+import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.team.dto.TeamRequest;
 import com.kdt.team04.domain.team.dto.TeamResponse;
@@ -38,17 +40,21 @@ class TeamServiceIntegrationTest {
 	@DisplayName("해당 사용자는 팀을 생성할 수 있고, 해당 팀의 리더가 된다.")
 	void testCreateSuccess() {
 		//given
-		User user = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
-		entityManager.persist(user);
-		TeamRequest.CreateRequest CREATE_REQUEST = new TeamRequest.CreateRequest("team1", "first team",
+		User teamCreator = getDemoUser();
+		TeamRequest.CreateRequest requestDto = new TeamRequest.CreateRequest("team1", "first team",
 			SportsCategory.BADMINTON);
 
 		//when
-		Long savedId = teamService.create(user.getId(), CREATE_REQUEST.name(), CREATE_REQUEST.sportsCategory(),
-			CREATE_REQUEST.description());
+		Long savedTeamId = teamService.create(teamCreator.getId(), requestDto);
+		Long leaderId = teamRepository.findById(savedTeamId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.TEAM_NOT_FOUND,
+				MessageFormat.format("TeamId = {0}", savedTeamId)))
+			.getLeader()
+			.getId();
 
 		//then
-		assertThat(savedId).isNotNull();
+		assertThat(savedTeamId).isNotNull();
+		assertThat(teamCreator.getId()).isEqualTo(leaderId);
 	}
 
 	@Test
@@ -104,6 +110,18 @@ class TeamServiceIntegrationTest {
 		//then
 		assertThat(foundTeams).hasSize(1);
 		assertThat(foundTeams.get(0).id()).isEqualTo(savedTeam.getId());
+	}
+
+	public User getDemoUser() {
+		User demoUser = User.builder()
+			.username("test1234")
+			.nickname("nickname")
+			.password("Test1234!!")
+			.build();
+
+		entityManager.persist(demoUser);
+
+		return demoUser;
 	}
 
 }

--- a/src/test/java/com/kdt/team04/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/team/service/TeamServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kdt.team04.common.exception.EntityNotFoundException;
@@ -77,21 +78,31 @@ class TeamServiceTest {
 
 	@Test
 	@DisplayName("팀 생성에 성공합니다.")
-	void createSuccess() {
+	void testCreateSuccess() {
 		//given
-		given(userService.findById(USER.getId())).willReturn(USER_RESPONSE);
-		given(userConverter.toUser(USER_RESPONSE)).willReturn(USER);
-		given(teamRepository.save(any(Team.class))).willReturn(TEAM);
+		User user = getDemoUser();
+		UserResponse userResponse = toUserResponse(user);
+		Team newTeam = Team.builder()
+			.id(1L)
+			.name("team1")
+			.description("first team")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.build();
+		TeamRequest.CreateRequest createRequest = new TeamRequest.CreateRequest("team1", "first team",
+			SportsCategory.BADMINTON);
+
+		given(userService.findById(any(Long.class))).willReturn(userResponse);
+		given(userConverter.toUser(userResponse)).willReturn(user);
+		given(teamRepository.save(any(Team.class))).willReturn(newTeam);
+
 		//when
-		Long teamId = teamService.create(USER.getId(), CREATE_REQUEST.name(),
-			CREATE_REQUEST.sportsCategory(),
-			CREATE_REQUEST.description());
+		Long teamId = teamService.create(user.getId(), createRequest);
 
 		//then
-		verify(userService, times(1)).findById(USER.getId());
+		verify(userService, times(1)).findById(user.getId());
 		verify(teamRepository, times(1)).save(any(Team.class));
 
-		assertThat(teamId).isEqualTo(TEAM.getId());
+		assertThat(teamId).isEqualTo(newTeam.getId());
 	}
 
 	@Test
@@ -123,5 +134,26 @@ class TeamServiceTest {
 		given(teamRepository.findById(invalidId)).willReturn(Optional.empty());
 
 		assertThatThrownBy(() -> teamService.findById(invalidId)).isInstanceOf(EntityNotFoundException.class);
+	}
+
+	public User getDemoUser() {
+		User demoUser = User.builder()
+			.username("test1234")
+			.nickname("nickname")
+			.password("test")
+			.build();
+
+		ReflectionTestUtils.setField(demoUser, "id", 10L);
+
+		return demoUser;
+	}
+
+	public UserResponse toUserResponse(User user) {
+		return UserResponse.builder()
+			.id(user.getId())
+			.username(user.getUsername())
+			.nickname(user.getNickname())
+			.location(user.getLocation())
+			.build();
 	}
 }

--- a/src/test/java/com/kdt/team04/domain/teammember/repository/TeamMemberRepositoryIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/teammember/repository/TeamMemberRepositoryIntegrationTest.java
@@ -30,6 +30,10 @@ class TeamMemberRepositoryIntegrationTest {
 	void existsByTeamIdAndMemberId() {
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+
+		User persistedUserA = entityManager.persist(userA);
+		entityManager.persist(userB);
+
 		Team team = Team.builder()
 			.name("teamA")
 			.description("description")
@@ -38,9 +42,8 @@ class TeamMemberRepositoryIntegrationTest {
 			.build();
 		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
 		TeamMember teamMemberB = new TeamMember(team, userB, TeamMemberRole.MEMBER);
+
 		Team persistedTeam = entityManager.persist(team);
-		User persistedUserA = entityManager.persist(userA);
-		entityManager.persist(userB);
 		entityManager.persist(teamMemberA);
 		entityManager.persist(teamMemberB);
 
@@ -53,6 +56,10 @@ class TeamMemberRepositoryIntegrationTest {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+
+		entityManager.persist(userA);
+		entityManager.persist(userB);
+
 		Team team = Team.builder()
 			.name("teamA")
 			.description("description")
@@ -60,9 +67,9 @@ class TeamMemberRepositoryIntegrationTest {
 			.leader(userA)
 			.build();
 		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
+
 		Team persistedTeam = entityManager.persist(team);
 		User persistedUserB = entityManager.persist(userB);
-
 		entityManager.persist(userA);
 		entityManager.persist(teamMemberA);
 

--- a/src/test/java/com/kdt/team04/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/user/service/UserServiceTest.java
@@ -167,7 +167,6 @@ class UserServiceTest {
 		assertThat(userResponse.id()).isEqualTo(user.getId());
 		assertThat(userResponse.username()).isEqualTo(user.getUsername());
 		assertThat(userResponse.nickname()).isEqualTo(user.getNickname());
-		assertThat(userResponse.password()).isEqualTo(user.getPassword());
 	}
 
 	@Test


### PR DESCRIPTION
## ✅  작업 단위

- [DK-347] 사용자가 팀을 생성할 수 있다 [스토리 리팩터링]

## 🤔 고민 했던 부분

- 파리미터가 4개이상인 생성자 전략을 builder를 적용하였음.
- 메소드 호출시에도 파라미터가 4개 이상인 부분을 requestDto로 넘겨줌.
- entity validation을 더욱 타이트하게 가져감.
- repository, validation test 를 추가 [Team Entity]
- 파급된 테스트 코드는 정상 동작함을 모두 확인했습니다.

## 🔊 HELP !!

- x

[DK-347]: https://insta-kkyu.atlassian.net/browse/DK-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ