### PR TITLE
[DK-382] fix:  매치 글 작성 시 위치 정보 삽입 누락 수정

### DIFF
--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchService.java
@@ -88,6 +88,7 @@ public class MatchService {
 			.user(user)
 			.sportsCategory(request.sportsCategory())
 			.content(request.content())
+			.location(user.getLocation())
 			.build();
 	}
 
@@ -117,6 +118,7 @@ public class MatchService {
 			.team(team)
 			.sportsCategory(request.sportsCategory())
 			.content(request.content())
+			.location(teamLeader.getLocation())
 			.build();
 	}
 


### PR DESCRIPTION
## ✅  작업 단위

- [[DK-382] fix: 매치 글 작성 시 위치 정보 삽입 누락 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/c38f4705a455d51a6aec1a945e53443687729ca7)
  - 매치 작성 시 위치 정보가 삽입되지 않았던 문제 수정했습니다.

한분이라도 확인하시면 머지하겠습니다..!

[DK-382]: https://insta-kkyu.atlassian.net/browse/DK-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ