### PR TITLE
[DK-384] 매칭 공고 상세 조회 API 수정 (신청 정보 추가)

### DIFF
--- a/src/main/java/com/kdt/team04/domain/matches/match/controller/MatchController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/controller/MatchController.java
@@ -62,9 +62,14 @@ public class MatchController {
 	@Operation(summary = "매치 공고 상세 조회", description = "매칭 공고의 세부 정보를 조회할 수 있다.")
 	@GetMapping("/{id}")
 	public ApiResponse<MatchResponse> getById(
-		@Parameter(description = "매칭 공고 ID") @PathVariable Long id
+		@Parameter(description = "매칭 공고 ID") @PathVariable Long id,
+		@AuthenticationPrincipal JwtAuthentication auth
 	) {
-		return new ApiResponse<>(matchService.findById(id));
+		if (auth == null) {
+			throw new NotAuthenticationException("Not Authenticated");
+		}
+
+		return new ApiResponse<>(matchService.findById(id, auth.id()));
 	}
 
 	@Operation(summary = "매칭 공고 삭제", description = "매칭 공고를 삭제할 수 있다.")

--- a/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchConverter.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchConverter.java
@@ -1,9 +1,12 @@
 package com.kdt.team04.domain.matches.match.dto;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
 import com.kdt.team04.domain.matches.match.dto.response.MatchResponse;
 import com.kdt.team04.domain.matches.match.entity.Match;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
 import com.kdt.team04.domain.team.dto.response.TeamSimpleResponse;
 import com.kdt.team04.domain.team.entity.Team;
 import com.kdt.team04.domain.user.dto.response.AuthorResponse;
@@ -25,8 +28,30 @@ public class MatchConverter {
 			.build();
 	}
 
-	public MatchResponse toMatchResponse(Match match, AuthorResponse user,
-		TeamSimpleResponse team) {
+	public MatchResponse toMatchResponse(
+		Match match,
+		AuthorResponse user,
+		Optional<ProposalSimpleResponse> proposer
+	) {
+		return MatchResponse.builder()
+			.id(match.getId())
+			.title(match.getTitle())
+			.status(match.getStatus())
+			.sportsCategory(match.getSportsCategory())
+			.author(user)
+			.participants(match.getParticipants())
+			.matchDate(match.getMatchDate())
+			.matchType(match.getMatchType())
+			.content(match.getContent())
+			.proposer(proposer)
+			.build();
+	}
+
+	public MatchResponse toMatchResponse(
+		Match match,
+		AuthorResponse user,
+		TeamSimpleResponse team
+	) {
 		return MatchResponse.builder()
 			.id(match.getId())
 			.title(match.getTitle())
@@ -38,6 +63,27 @@ public class MatchConverter {
 			.matchDate(match.getMatchDate())
 			.matchType(match.getMatchType())
 			.content(match.getContent())
+			.build();
+	}
+
+	public MatchResponse toMatchResponse(
+		Match match,
+		AuthorResponse user,
+		TeamSimpleResponse team,
+		Optional<ProposalSimpleResponse> proposer
+	) {
+		return MatchResponse.builder()
+			.id(match.getId())
+			.title(match.getTitle())
+			.status(match.getStatus())
+			.sportsCategory(match.getSportsCategory())
+			.author(user)
+			.team(team)
+			.participants(match.getParticipants())
+			.matchDate(match.getMatchDate())
+			.matchType(match.getMatchType())
+			.content(match.getContent())
+			.proposer(proposer)
 			.build();
 	}
 

--- a/src/main/java/com/kdt/team04/domain/matches/match/dto/response/MatchResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/dto/response/MatchResponse.java
@@ -1,9 +1,11 @@
 package com.kdt.team04.domain.matches.match.dto.response;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import com.kdt.team04.domain.matches.match.entity.MatchStatus;
 import com.kdt.team04.domain.matches.match.entity.MatchType;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
 import com.kdt.team04.domain.team.SportsCategory;
 import com.kdt.team04.domain.team.dto.response.TeamSimpleResponse;
 import com.kdt.team04.domain.user.dto.response.AuthorResponse;
@@ -41,6 +43,9 @@ public record MatchResponse(
 	MatchType matchType,
 
 	@Schema(description = "매칭 글 내용")
-	String content
+	String content,
+
+	@Schema(description = "매칭 신청 정보(로그인한 사용자가 신청했다면 정보 포함 | 아니라면 null 반환)")
+	Optional<ProposalSimpleResponse> proposer
 ) {
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalIdResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalIdResponse.java
@@ -1,5 +1,5 @@
 package com.kdt.team04.domain.matches.proposal.dto.response;
 
-public record ProposalSimpleResponse(
+public record ProposalIdResponse(
 	Long id
 ) {}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalSimpleResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalSimpleResponse.java
@@ -1,0 +1,10 @@
+package com.kdt.team04.domain.matches.proposal.dto.response;
+
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
+
+public record ProposalSimpleResponse(
+	Long id,
+	MatchProposalStatus status,
+	String content
+) {
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
@@ -21,4 +21,7 @@ public interface MatchProposalRepository extends JpaRepository<MatchProposal, Lo
 
 	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH mp.user LEFT JOIN FETCH mp.team WHERE mp.id = :id")
 	Optional<MatchProposal> findProposalById(@Param("id") Long id);
+
+	@Query("SELECT mp FROM MatchProposal mp WHERE mp.match.id = :matchId AND mp.user.id = :userId")
+	Optional<MatchProposal> findByMatchIdAndUserId(@Param("matchId") Long matchId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchChatService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchChatService.java
@@ -21,7 +21,7 @@ import com.kdt.team04.domain.matches.proposal.dto.response.ChatLastResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChattingResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalChatMatchResponse;
-import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalIdResponse;
 import com.kdt.team04.domain.matches.proposal.entity.MatchChat;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
@@ -124,7 +124,7 @@ public class MatchChatService {
 	}
 
 	@Transactional
-	public void deleteAllByProposals(List<ProposalSimpleResponse> proposalResponses) {
+	public void deleteAllByProposals(List<ProposalIdResponse> proposalResponses) {
 		List<MatchProposal> proposals = proposalResponses.stream()
 			.map((proposal -> MatchProposal.builder()
 				.id(proposal.id())

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -19,7 +19,7 @@ import com.kdt.team04.domain.matches.match.service.MatchGiverService;
 import com.kdt.team04.domain.matches.proposal.dto.request.ProposalCreateRequest;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChatLastResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalChatResponse;
-import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalIdResponse;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.kdt.team04.domain.matches.proposal.repository.MatchProposalRepository;
@@ -194,8 +194,8 @@ public class MatchProposalService {
 	@Transactional
 	public void deleteByMatches(Long matchId) {
 		List<MatchProposal> foundProposals = proposalRepository.findAllByMatchId(matchId);
-		List<ProposalSimpleResponse> proposalResponses = foundProposals.stream()
-			.map(response -> new ProposalSimpleResponse(response.getId()))
+		List<ProposalIdResponse> proposalResponses = foundProposals.stream()
+			.map(response -> new ProposalIdResponse(response.getId()))
 			.toList();
 		matchChatService.deleteAllByProposals(proposalResponses);
 		proposalRepository.deleteAllByMatchId(matchId);

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -4,6 +4,7 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import com.kdt.team04.domain.matches.proposal.dto.request.ProposalCreateRequest;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChatLastResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalIdResponse;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 import com.kdt.team04.domain.matches.proposal.repository.MatchProposalRepository;
@@ -199,5 +201,14 @@ public class MatchProposalService {
 			.toList();
 		matchChatService.deleteAllByProposals(proposalResponses);
 		proposalRepository.deleteAllByMatchId(matchId);
+	}
+
+	public Optional<ProposalSimpleResponse> findByMatchIdAndUserId(Long matchId, Long userId) {
+		return proposalRepository.findByMatchIdAndUserId(matchId, userId)
+			.map(proposal -> new ProposalSimpleResponse(
+				proposal.getId(),
+				proposal.getStatus(),
+				proposal.getContent()
+			));
 	}
 }

--- a/src/test/java/com/kdt/team04/domain/matches/match/service/MatchServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/match/service/MatchServiceIntegrationTest.java
@@ -207,7 +207,7 @@ class MatchServiceIntegrationTest {
 			.build());
 
 		//when
-		MatchResponse foundMatch = matchService.findById(savedMatch.getId());
+		MatchResponse foundMatch = matchService.findById(savedMatch.getId(), user.getId());
 
 		//then
 		assertThat(foundMatch.title()).isEqualTo(savedMatch.getTitle());
@@ -224,7 +224,8 @@ class MatchServiceIntegrationTest {
 		//given
 		Long invalidId = 1234L;
 		//when, then
-		assertThatThrownBy(() -> matchService.findById(invalidId)).isInstanceOf(EntityNotFoundException.class);
+		assertThatThrownBy(() -> matchService.findById(invalidId, 1L))
+			.isInstanceOf(EntityNotFoundException.class);
 	}
 
 	@Test

--- a/src/test/java/com/kdt/team04/domain/matches/request/service/MatchChatServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/request/service/MatchChatServiceIntegrationTest.java
@@ -37,7 +37,7 @@ import com.kdt.team04.domain.matches.proposal.dto.response.ChatLastResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChattingResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalChatMatchResponse;
-import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalIdResponse;
 import com.kdt.team04.domain.matches.proposal.entity.MatchChat;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
@@ -362,9 +362,9 @@ class MatchChatServiceIntegrationTest {
 		matchChatRepository.save(chat2);
 		matchChatRepository.save(chat3);
 
-		List<ProposalSimpleResponse> proposals = List.of(
-			new ProposalSimpleResponse(matchProposal1.getId()),
-			new ProposalSimpleResponse(matchProposal2.getId()));
+		List<ProposalIdResponse> proposals = List.of(
+			new ProposalIdResponse(matchProposal1.getId()),
+			new ProposalIdResponse(matchProposal2.getId()));
 		//when
 		matchChatService.deleteAllByProposals(proposals);
 


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-384] refactor: 매칭 신청 간단 Response 네이밍 변경 (→ ProposalIdResponse)](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/c98ca59fc8671b7c2820f26e810aed11a30a8f37)
- 기존의 SimpleResponse가 Id 필드밖에 없어 네이밍을 변경했습니다.

### [[DK-384] feat: 매칭 공고 상세 조회 API 수정 (신청 정보 추가)](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/71dab8413a7a2c458ee254d227b6cbb2938d346f)
- ProposalSimpleResponse 생성
- 게시글 공고 상세 페이지에서 로그인한 사용자가 신청자라면 신청정보가 나오도록 기능 추가
   ([DK-384](https://insta-kkyu.atlassian.net/browse/DK-384?atlOrigin=eyJpIjoiNmFiODBkN2Q1N2U3NDRjMGFmY2QxYWJlNjE5MTZiOGEiLCJwIjoiaiJ9)지라 티켓 참고 바람)

## 🤔 고민 했던 부분
```java
public record MatchResponse(
	...
	@Schema(description = "매칭 신청 정보(로그인한 사용자가 신청했다면 정보 포함 | 아니라면 null 반환)")
	Optional<ProposalSimpleResponse> proposer
) {
}
```
- proposal로 하려다가 로그인된 사용자가 신청자라는 전제하에 나오는 정보라고 생각해서 신청자라는 네이밍을 했습니다만..? 🤔
   어떤 네이밍을 할지 잘모르겠네요.


[DK-384]: https://insta-kkyu.atlassian.net/browse/DK-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-384]: https://insta-kkyu.atlassian.net/browse/DK-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ