### PR TITLE
[DK-392] 팀 생성 API 수정 - 팀 이름 중복 불가 추가

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
 	//TEAM
 	TEAM_NOT_FOUND("T0001", "Not found team", HttpStatus.NOT_FOUND),
 	NOT_TEAM_LEADER("T0002", "Not team leader", HttpStatus.FORBIDDEN),
+	TEAM_DUPLICATE_NAME("T0003", "Duplicate team name", HttpStatus.BAD_REQUEST),
 
 	//TEAM_INVITATION
 	TEAM_INVITATION_NOT_FOUND("I0001", "Not found invitation", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/kdt/team04/domain/teams/team/model/entity/Team.java
+++ b/src/main/java/com/kdt/team04/domain/teams/team/model/entity/Team.java
@@ -1,5 +1,6 @@
 package com.kdt.team04.domain.teams.team.model.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -31,6 +32,7 @@ public class Team extends BaseEntity {
 
 	@NotBlank
 	@Size(min = 2, max = 10)
+	@Column(unique = true)
 	private String name;
 
 	@NotBlank

--- a/src/main/java/com/kdt/team04/domain/teams/team/repository/TeamRepository.java
+++ b/src/main/java/com/kdt/team04/domain/teams/team/repository/TeamRepository.java
@@ -17,4 +17,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 	List<Team> findAllByTeamMemberUserId(@Param("userId") Long userId);
 
 	Optional<Team> findByIdAndLeaderId(Long id, Long leaderId);
+
+	Boolean existsByName(String name);
 }

--- a/src/main/java/com/kdt/team04/domain/teams/team/service/TeamService.java
+++ b/src/main/java/com/kdt/team04/domain/teams/team/service/TeamService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.kdt.team04.common.exception.BusinessException;
 import com.kdt.team04.common.exception.EntityNotFoundException;
 import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.common.file.ImagePath;
@@ -58,6 +59,13 @@ public class TeamService {
 
 	@Transactional
 	public Long create(Long userId, CreateTeamRequest requestDto) {
+		boolean existsName = teamRepository.existsByName(requestDto.name());
+
+		if (existsName) {
+			throw new BusinessException(ErrorCode.TEAM_DUPLICATE_NAME,
+				MessageFormat.format("teamName={0}, userId={1}", requestDto.name(), userId));
+		}
+
 		User user = userConverter.toUser(userService.findById(userId));
 		Team savedTeam = teamRepository.save(
 			Team.builder()

--- a/src/main/resources/db/migration/V7_2__Alter_team_change_column_name_unique_key.sql
+++ b/src/main/resources/db/migration/V7_2__Alter_team_change_column_name_unique_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE team MODIFY name varchar(10) UNIQUE KEY NOT NULL;

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
@@ -98,7 +98,7 @@ class MatchProposalServiceIntegrationTest {
 		entityManager.persist(author);
 
 		Team authorTeam = Team.builder()
-			.name("team1")
+			.name("author")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(author)
@@ -117,8 +117,8 @@ class MatchProposalServiceIntegrationTest {
 		proposer.updateSettings(new UserSettings(1.1, 1.2, 10));
 
 		Team proposerTeam = Team.builder()
-			.name("team1")
-			.description("first team")
+			.name("proposer")
+			.description("proposer team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
 			.build();
@@ -161,7 +161,7 @@ class MatchProposalServiceIntegrationTest {
 		entityManager.persist(author);
 
 		Team authorTeam = Team.builder()
-			.name("team1")
+			.name("author")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(author)
@@ -176,7 +176,7 @@ class MatchProposalServiceIntegrationTest {
 
 		proposer.updateSettings(new UserSettings(1.1, 1.2, 10));
 		Team proposerTeam = Team.builder()
-			.name("team1")
+			.name("proposer")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
@@ -217,13 +217,13 @@ class MatchProposalServiceIntegrationTest {
 		entityManager.persist(proposer);
 
 		Team authorTeam = Team.builder()
-			.name("team1")
+			.name("author")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)
 			.build();
 		Team proposerTeam = Team.builder()
-			.name("team1")
+			.name("proposer")
 			.description("first team")
 			.sportsCategory(SportsCategory.BADMINTON)
 			.leader(proposer)

--- a/src/test/java/com/kdt/team04/domain/teams/team/service/TeamServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/teams/team/service/TeamServiceIntegrationTest.java
@@ -16,16 +16,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.kdt.team04.common.aws.s3.S3Uploader;
+import com.kdt.team04.common.exception.BusinessException;
 import com.kdt.team04.common.exception.EntityNotFoundException;
 import com.kdt.team04.common.exception.ErrorCode;
-import com.kdt.team04.common.aws.s3.S3Uploader;
-import com.kdt.team04.domain.teams.team.model.SportsCategory;
 import com.kdt.team04.domain.teams.team.dto.request.CreateTeamRequest;
 import com.kdt.team04.domain.teams.team.dto.response.TeamResponse;
 import com.kdt.team04.domain.teams.team.dto.response.TeamSimpleResponse;
+import com.kdt.team04.domain.teams.team.model.SportsCategory;
 import com.kdt.team04.domain.teams.team.model.entity.Team;
 import com.kdt.team04.domain.teams.team.repository.TeamRepository;
-import com.kdt.team04.domain.teams.team.service.TeamService;
 import com.kdt.team04.domain.user.entity.User;
 
 @SpringBootTest
@@ -66,6 +66,23 @@ class TeamServiceIntegrationTest {
 		//then
 		assertThat(savedTeamId).isNotNull();
 		assertThat(teamCreator.getId()).isEqualTo(leaderId);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("같은 이름으로 팀 등록 시, 중복 오류가 발생한다.")
+	void createFail_DuplicateTeamName() {
+		//given
+		User teamCreator = getDemoUser();
+		CreateTeamRequest requestDto = new CreateTeamRequest("team1", "first team",
+			SportsCategory.BADMINTON);
+
+		teamService.create(teamCreator.getId(), requestDto);
+
+		//when, then
+		assertThatThrownBy(() -> {
+			teamService.create(teamCreator.getId(), requestDto);
+		}).isInstanceOf(BusinessException.class);
 	}
 
 	@Test


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-392] feat: 팀 생성 API 수정 - 팀 이름 중복 불가 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/d50fbf5933b2fd6cb28ffbd5075107e510775d6b)
- 팀 생성 시, 중복 추가 안되도록 중복 체크 구문 추가
- 팀 테이블 - 이름에 Unique Key 추가 Flyway 스크립트 작성 (V 7.2)

### [[DK-392] test: 팀 생성 API 수정 - 팀 이름 중복 불가 케이스 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/0f8529e5661dbcd45d2f9c71bec5220b2532b86b)
- 오류 케이스 추가

### [[DK-392] test: 팀 이름 중복 안되도록 테스트 코드 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/dd9039482d0153b1a85e5d3d4bbf39a221fa0627)
- 같은 이름으로 팀 생성하는 테스트 코드 수정

## 🤔 고민 했던 부분

- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🔊 HELP !!

- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 💣 주의 사항.
본 DB에 팀 이름 중복되는 이름 데이터 삭제한 상태입니다.
배포 시에 중복되는 이름 있는 경우.. Flyway 오류 발생할 수 있을지도?

[DK-392]: https://insta-kkyu.atlassian.net/browse/DK-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-392]: https://insta-kkyu.atlassian.net/browse/DK-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-392]: https://insta-kkyu.atlassian.net/browse/DK-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ