### PR TITLE
[DK-413] 매칭 신청 API 수정 - 중복 신청 안되도록 로직 추가

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
 	ANOTHER_PROPOSAL_ALREADY_FIXED("MP0004", "Fixed another proposal already exists.", HttpStatus.BAD_REQUEST),
 	PROPOSAL_INVALID_REACT("MP0005", "Invalid react", HttpStatus.BAD_REQUEST),
 	PROPOSAL_ACCESS_DENIED("MP0006", "Don't have permission to access match proposal", HttpStatus.FORBIDDEN),
+	PROPOSAL_ALREADY_REQUESTED("MP0007", "Already requested", HttpStatus.BAD_REQUEST),
 
 	//MATCH_CHAT
 	MATCH_CHAT_NOT_CORRECT_CHAT_PARTNER("MC0002", "The chat partner is incorrect.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/CustomMatchProposalRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/CustomMatchProposalRepository.java
@@ -11,4 +11,5 @@ public interface CustomMatchProposalRepository {
 	Optional<QueryMatchProposalSimpleResponse> findSimpleProposalById(Long id);
 	Optional<QueryMatchProposalResponse> findFixedProposalByMatchId(Long matchId);
 	List<QueryProposalChatResponse> findAllProposalByUserId(Long userId);
+	boolean existsByMatchIdAndUserId(Long matchId, Long userId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/CustomMatchProposalRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/CustomMatchProposalRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.kdt.team04.domain.matches.proposal.repository;
 import static com.kdt.team04.domain.matches.match.model.entity.QMatch.match;
 import static com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus.FIXED;
 import static com.kdt.team04.domain.matches.proposal.entity.QMatchProposal.matchProposal;
+import static com.kdt.team04.domain.matches.review.model.entity.QMatchReview.matchReview;
 
 import java.util.List;
 import java.util.Optional;
@@ -101,5 +102,18 @@ public class CustomMatchProposalRepositoryImpl implements CustomMatchProposalRep
 			nativeQuery,
 			QueryProposalChatResponse.class
 		);
+	}
+
+	@Override
+	public boolean existsByMatchIdAndUserId(Long matchId, Long userId) {
+		Integer exists = queryFactory
+			.selectOne()
+			.from(matchProposal)
+			.where(
+				matchProposal.match.id.eq(matchId),
+				matchProposal.user.id.eq(userId)
+			).fetchFirst();
+
+		return exists != null;
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -87,6 +87,13 @@ public class MatchProposalService {
 				proposerId, matchResponse.author().id()));
 		}
 
+		boolean existsProposal = proposalRepository.existsByMatchIdAndUserId(matchId, proposerId);
+
+		if (existsProposal) {
+			throw new BusinessException(ErrorCode.PROPOSAL_ALREADY_REQUESTED,
+				MessageFormat.format("Already proposal requested, matchId = {0}, proposerId = {1}", matchId, proposerId));
+		}
+
 		UserResponse authorResponse = userService.findById(matchResponse.author().id());
 		User author = userConverter.toUser(authorResponse);
 


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-413] feat: 매칭 신청 API 수정 - 중복 신청 안되도록 로직 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/341198662ebb367a736c6a1b814d0baeba6f8fe3)
- 사용자가 2번 신청을 하게 되면 중복 오류가 발생 되도록 구현 했습니다. (머지 되면 에러코드 노션에 업데이트 하겠습니다.)

진형님이 팀전인 경우 팀 ID로 중복 검사를 하는 방법을 알려주셨는데,
곰곰히 생각을 해보니.. 채팅 자체가 신청한 사용자만 가능 해서 
→ 신청하고 바뀌게 되면 어차피 대화가 안되는디...? 등 생각이 이어져서 그냥 사용자 ID 기준으로 했습니다.

### [[DK-413] feat: 매칭 신청 API 수정 - 중복 여부 조회 메서드(V2) 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/56a5acba3df6a0713d1fc6b8fc61300bc0652c00)
요 부분이 왜 있느냐 말이지요? 👀
기존 표준 스펙 쿼리가 조인이 갑자기 튀어나와서 V2를 제작하게 되었습니다. 조인 제거 방법 있으면 알려주세요. 🫠
- 기존 표준 스펙의 메서드 사용 시..
  ![image](https://user-images.githubusercontent.com/93169519/183639460-998dfbd7-4a25-42a3-96b9-ab1e4e807b1a.png)
  ![image](https://user-images.githubusercontent.com/93169519/183639396-00454b2f-a11a-4899-8f6a-40ba8c53f595.png)
- QueryDSL로 작성 시..
  ![image](https://user-images.githubusercontent.com/93169519/183639593-e2ddf480-d19e-4b7d-9ad9-460aab52fc9a.png)
  ![image](https://user-images.githubusercontent.com/93169519/183639639-f088c1c0-0ec9-412f-8b0e-ca79b716b044.png)


### [[DK-413] test: 매칭 신청 API 수정 - 중복 신청 테스트 코드 작성](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/907d42a40cf5963e7aba4519129f6c7796861193)
- 팀전, 개인전 각각 중복 오류 테스트 추가 했습니다.

## 🤔 고민 했던 부분

- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🔊 HELP !!

- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

[DK-413]: https://insta-kkyu.atlassian.net/browse/DK-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-413]: https://insta-kkyu.atlassian.net/browse/DK-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-413]: https://insta-kkyu.atlassian.net/browse/DK-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ