### PR TITLE
[Dk-176] REAL, DEV 환경 분리

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/ErrorResponse.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorResponse.java
@@ -1,12 +1,16 @@
 package com.kdt.team04.common.exception;
 
+import java.time.LocalDateTime;
+
 public class ErrorResponse<T extends ErrorCode> {
 	private final String code;
 	private final String message;
+	private final LocalDateTime dateTime;
 
 	public ErrorResponse(T errorCode) {
 		this.code = errorCode.getCode();
 		this.message = errorCode.getMessage();
+		this.dateTime = LocalDateTime.now();
 	}
 
 	public String getCode() {
@@ -15,5 +19,9 @@ public class ErrorResponse<T extends ErrorCode> {
 
 	public String getMessage() {
 		return message;
+	}
+
+	public LocalDateTime dateTime() {
+		return dateTime;
 	}
 }

--- a/src/main/java/com/kdt/team04/common/security/CookieConfigProperties.java
+++ b/src/main/java/com/kdt/team04/common/security/CookieConfigProperties.java
@@ -6,5 +6,5 @@ import org.springframework.boot.web.server.Cookie;
 
 @ConstructorBinding
 @ConfigurationProperties(prefix = "cookie")
-public record CookieConfigProperties(Boolean secure, Cookie.SameSite sameSite) {
+public record CookieConfigProperties(Boolean secure, Cookie.SameSite sameSite, String domain) {
 }

--- a/src/main/java/com/kdt/team04/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/kdt/team04/common/security/WebSecurityConfig.java
@@ -31,16 +31,19 @@ public class WebSecurityConfig {
 	private final Jwt jwt;
 	private final SecurityConfigProperties securityConfigProperties;
 	private final Optional<OAuth2LoginConfigurer<HttpSecurity>> oAuth2LoginConfigurer;
+	private final CookieConfigProperties cookieConfigProperties;
 
 	public WebSecurityConfig(Jwt jwt, SecurityConfigProperties securityConfigProperties,
-		Optional<OAuth2LoginConfigurer<HttpSecurity>> oAuth2LoginConfigurer) {
+		Optional<OAuth2LoginConfigurer<HttpSecurity>> oAuth2LoginConfigurer,
+		CookieConfigProperties cookieConfigProperties) {
 		this.jwt = jwt;
 		this.securityConfigProperties = securityConfigProperties;
 		this.oAuth2LoginConfigurer = oAuth2LoginConfigurer;
+		this.cookieConfigProperties = cookieConfigProperties;
 	}
 
 	public JwtAuthenticationFilter jwtAuthenticationFilter(Jwt jwt, TokenService tokenService) {
-		return new JwtAuthenticationFilter(jwt, tokenService);
+		return new JwtAuthenticationFilter(jwt, tokenService, cookieConfigProperties);
 	}
 
 	@Bean

--- a/src/main/java/com/kdt/team04/common/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/kdt/team04/common/security/oauth/OAuth2SuccessHandler.java
@@ -52,6 +52,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 			.path("/")
 			.httpOnly(true)
 			.secure(cookieConfigProperties.secure())
+			.domain(cookieConfigProperties.domain())
 			.maxAge(expirySeconds)
 			.sameSite(cookieConfigProperties.sameSite().attributeValue())
 			.build();

--- a/src/main/java/com/kdt/team04/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kdt/team04/domain/auth/controller/AuthController.java
@@ -72,6 +72,7 @@ public class AuthController {
 			.path("/")
 			.httpOnly(true)
 			.secure(cookieConfigProperties.secure())
+			.domain(cookieConfigProperties.domain())
 			.maxAge(expirySecond)
 			.sameSite(cookieConfigProperties.sameSite().attributeValue())
 			.build();

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -47,5 +47,6 @@ encryptor:
   key: ${ENCRYPTOR_KEY}
 
 cookie:
-  secure: true
-  same-site: NONE
+  secure: ${COOKIE_SECURE:true}
+  same-site: ${COOKIE_SAME_SITE:NONE}
+  domain: ${COOKIE_DOMAIN:.dongkyurami.link}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -47,6 +47,8 @@ cloud:
     stack:
       auto: false
     region: ${AWS_REGION:ENC(ayPRiqCMtSXBerKcGgVo29E2r606Z1Ht)}
-
+cookie:
+  secure: ${COOKIE_SECURE:false}
+  same-site: ${COOKIE_SAME_SITE:lax}
 encryptor:
   key: ${ENCRYPTOR_KEY}

--- a/src/main/resources/application-mem.yml
+++ b/src/main/resources/application-mem.yml
@@ -39,6 +39,8 @@ cors:
       - https://localhost:3000
 jwt:
   client-secret: ${JWT_SECRET:DEFAULT_JWT_SECRET}
-
+cookie:
+  secure: ${COOKIE_SECURE:false}
+  same-site: ${COOKIE_SAME_SITE:lax}
 encryptor:
   key: ${ENCRYPTOR_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,9 +50,6 @@ feign:
     config:
       default:
         loggerLevel: basic
-cookie:
-  secure: false
-  same-site: lax
 division:
   key: ${DIVISION_KEY:CEB52025-E065-364C-9DBA-44880E3B02B8}
   domain: ${DIVISION_DOMAIN:http://localhost:8080}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -48,7 +48,9 @@
     </springProfile>
 
     <springProfile name="real">
+        <include resource="logback/properties-real.xml" />
         <include resource="logback/file-db-appender.xml" />
+        <include resource="logback/cloud-watch-appender.xml" />
         <include resource="logback/file-error-appender.xml" />
 
         <root level="INFO">

--- a/src/main/resources/logback/properties-real.xml
+++ b/src/main/resources/logback/properties-real.xml
@@ -1,0 +1,15 @@
+<included>
+    <timestamp datePattern="yyyy-MM-dd" key="LOG_DATE"/>
+
+    <property name="ROOT_PATH" value="/home/ec2-user/app/team04/log"/>
+    <property name="SUB_PATH_ERROR" value="error"/>
+    <property name="SUB_PATH_WARN" value="warn"/>
+    <property name="SUB_PATH_DB" value="db"/>
+    <property name="LOG_BACKUP_PATH" value="/home/ec2-user/app/team04/log/backup"/>
+
+    <property name="MAX_HISTORY" value="30"/>
+    <property name="TOTAL_SIZE_CAP" value="10GB"/>
+
+    <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %cyan(%logger{15}) %C.%M.%L :%msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] [%thread] %-5level %logger{15} %C.%M.%L :%msg%n"/>
+</included>


### PR DESCRIPTION
## ✅  작업 단위

- [setting: submodule real yaml 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/e08bc60814e07ada3b842bd9216748edecb1d3da)
  - 서브모듈에 real 프로파일 추가했습니다
  - 별도의 free tier rds를 만들어 추가해줬습니다.
  - 암호화 키와 rds계정 정보는 dev와 다릅니다.(필요하시면 저한테 개인적으로 여쭤봐주세요)


- [feat: ErrorResponse에 에러 시간 포함](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/8920c2e86f2add08ee979c499e5796249fdecf20)
  - 프론트 팀과 에러를 식별하고 디버깅하는데 에러가 발생한 시간을 통해 로그를 찾아가게 되기 때문에 응답에 시간이 포함되는것이 필요해보였습니다.
- [feat: real 환경 로그백 설정 추가(클라우드워치, 프로퍼티)](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/7ab88cca6cb8de7c18de451a300ef5787a662af3)
  - 클라우드 워치 관련 설정 추가하고 , real환경 로그백 프로퍼티를 따로만들어 설정해줬습니다.

- [setting: real환경 cookie domain설정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/91163facfb357b1f39b57b9c998555f5486a02c3)
  - 쿠키에 도메인 설정을해서 api.dongkyurami.link와 www.dongkyurami.link에 대해서 쿠키를 사용할 수 있도록 하려고 합니다.(잘될지 모르겠습니다 aws에 올려보고 테스트 해야될듯?

