### PR TITLE
[DK-417] 신청 정보 조회(By Id) API 구현

### DIFF
--- a/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
@@ -86,11 +86,11 @@ public class MatchProposalController {
 
 	@Operation(summary = "신청 정보 조회", description = "신청 정보를 조회한다.")
 	@GetMapping("/proposals/{id}")
-	public ApiResponse<Optional<ProposalChatResponse>> getProposalById(
+	public ApiResponse<ProposalChatResponse> getProposalById(
 		@AuthUser JwtAuthentication auth,
 		@Parameter(description = "매칭 신청 ID") @PathVariable Long id
 	) {
-		Optional<ProposalChatResponse> proposal = matchProposalService.findById(id, auth.id());
+		ProposalChatResponse proposal = matchProposalService.findById(id, auth.id());
 
 		return new ApiResponse<>(proposal);
 	}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
@@ -1,6 +1,7 @@
 package com.kdt.team04.domain.matches.proposal.controller;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.validation.Valid;
 
@@ -20,6 +21,8 @@ import com.kdt.team04.domain.matches.proposal.dto.QueryProposalChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.request.CreateProposalRequest;
 import com.kdt.team04.domain.matches.proposal.dto.request.ReactProposalRequest;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChatRoomResponse;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalChatResponse;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
 import com.kdt.team04.domain.matches.proposal.service.MatchProposalService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -79,5 +82,16 @@ public class MatchProposalController {
 		);
 
 		return new ApiResponse<>(proposals);
+	}
+
+	@Operation(summary = "신청 정보 조회", description = "신청 정보를 조회한다.")
+	@GetMapping("/proposals/{id}")
+	public ApiResponse<Optional<ProposalChatResponse>> getProposalById(
+		@AuthUser JwtAuthentication auth,
+		@Parameter(description = "매칭 신청 ID") @PathVariable Long id
+	) {
+		Optional<ProposalChatResponse> proposal = matchProposalService.findById(id, auth.id());
+
+		return new ApiResponse<>(proposal);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalChatResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalChatResponse.java
@@ -1,0 +1,20 @@
+package com.kdt.team04.domain.matches.proposal.dto.response;
+
+import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProposalChatResponse(
+	@Schema(description = "신청 Id(고유 PK)")
+	Long id,
+
+	@Schema(description = "신청 상태(값/설명) - WAITING/대기중, APPROVED/수락, REFUSE/거절, FIXED/대상확정(경기종료)")
+	MatchProposalStatus status,
+
+	@Schema(description = "신청 내용")
+	String content,
+
+	@Schema(description = "사용자가 매칭 공고글 작성자인지 여부")
+	boolean isMatchAuthor
+) {
+}

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalChatResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/dto/response/ProposalChatResponse.java
@@ -3,7 +3,9 @@ package com.kdt.team04.domain.matches.proposal.dto.response;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposalStatus;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
+@Builder
 public record ProposalChatResponse(
 	@Schema(description = "신청 Id(고유 PK)")
 	Long id,

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
@@ -22,6 +22,9 @@ public interface MatchProposalRepository extends JpaRepository<MatchProposal, Lo
 	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH mp.user LEFT JOIN FETCH mp.team WHERE mp.id = :id")
 	Optional<MatchProposal> findProposalById(@Param("id") Long id);
 
+	@Query("SELECT mp FROM MatchProposal mp INNER JOIN Match m ON mp.match.id = m.id WHERE mp.id = :id AND (m.user.id = :userId OR mp.user.id = :userId)")
+	Optional<MatchProposal> findProposalWithMatchByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
+
 	@Query("SELECT mp FROM MatchProposal mp WHERE mp.match.id = :matchId AND mp.user.id = :userId")
 	Optional<MatchProposal> findByMatchIdAndUserId(@Param("matchId") Long matchId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/repository/MatchProposalRepository.java
@@ -22,8 +22,8 @@ public interface MatchProposalRepository extends JpaRepository<MatchProposal, Lo
 	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH mp.user LEFT JOIN FETCH mp.team WHERE mp.id = :id")
 	Optional<MatchProposal> findProposalById(@Param("id") Long id);
 
-	@Query("SELECT mp FROM MatchProposal mp INNER JOIN Match m ON mp.match.id = m.id WHERE mp.id = :id AND (m.user.id = :userId OR mp.user.id = :userId)")
-	Optional<MatchProposal> findProposalWithMatchByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
+	@Query("SELECT mp FROM MatchProposal mp JOIN FETCH mp.match WHERE mp.id = :id")
+	Optional<MatchProposal> findProposalWithMatchById(@Param("id") Long id);
 
 	@Query("SELECT mp FROM MatchProposal mp WHERE mp.match.id = :matchId AND mp.user.id = :userId")
 	Optional<MatchProposal> findByMatchIdAndUserId(@Param("matchId") Long matchId, @Param("userId") Long userId);

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -21,6 +21,7 @@ import com.kdt.team04.domain.matches.proposal.dto.QueryProposalChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.request.CreateProposalRequest;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChatRoomResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.LastChatResponse;
+import com.kdt.team04.domain.matches.proposal.dto.response.ProposalChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalIdResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
 import com.kdt.team04.domain.matches.proposal.entity.MatchProposal;
@@ -221,6 +222,16 @@ public class MatchProposalService {
 				proposal.getId(),
 				proposal.getStatus(),
 				proposal.getContent()
+			));
+	}
+
+	public Optional<ProposalChatResponse> findById(Long id, Long userId) {
+		return proposalRepository.findProposalWithMatchByIdAndUserId(id, userId)
+			.map(proposal -> new ProposalChatResponse(
+				proposal.getId(),
+				proposal.getStatus(),
+				proposal.getContent(),
+				proposal.getUser().getId() != userId
 			));
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-417] feat: 신청 정보 조회(By Id) API 구현](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/7941e1dd6fc7fd89a4e468f37d81eb655e13ca53)
- 신청 Id로 해당 신청 정보 조회 하는 API 구현
- 신청자 or 작성자가 아닌 경우 결과값은 null 값 반환

![image](https://user-images.githubusercontent.com/93169519/183830316-10288194-4306-4281-984c-f58b72edc2e5.png)
- isMatchAuthor : 로그인 된 사용자가 해당 매칭 공고글의 작성자 인지 아닌지 여부를 판단하는 용도 입니다.
  ![image](https://user-images.githubusercontent.com/93169519/183830523-2501447e-f2f5-4646-8c6d-69116bb38dbe.png)
  해당 화면에서 사용되는 API인데, 작성자인 경우에는 수락 / 거절 여부를 띄워줘야 하기 때문에 **작성자 여부 판단**을 위해 추가
  (신청자인 경우에는 상태 값만 알면 됨)

프론트 분들 연동이 우선인것 같아서 기능 먼저 개발 했습니다.
테스트 코드는 추후에 바로 추가(금일 내로) 하겠습니다.

### [[DK-417] feat: 공고글 작성자 또는 신청자가 아닌 경우 오류 발생 되도록 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/pull/72/commits/caa39a1cd7f3bf08423d4c1a1534f593898c188f)
- 기존 INNER JOIN을 Fetch Join으로 변경 했습니다.
  이렇게 됬을 때 match 정보까지 함께 가져오기 때문에, 로직 자체를 변경 했습니다.
  - 해당 Id가 존재하지 않을 경우 EMPTY 오류 발생
  - 공고글 작성자 또는 신청자가 아닌 경우 접근 권한 오류 발생

OK 되면 해당 건 Squash로 합쳐서 머지하겠습니다.

## 🤔 고민 했던 부분

- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🔊 HELP !!

- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

[DK-417]: https://insta-kkyu.atlassian.net/browse/DK-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ