### PR TITLE
[DK-437] 팀 초대 중복 버그 수정 및 검증로직 추가

### DIFF
--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 	TEAM_INVITATION_NOT_FOUND("I0001", "Not found invitation", HttpStatus.NOT_FOUND),
 	INVALID_TEAM_INVITATION("I0002", "Invalid invitation", HttpStatus.BAD_REQUEST),
 	ALREADY_INVITED_USER("I0003", "Invitation is already approval or wait.", HttpStatus.BAD_REQUEST),
+	TEAM_INVITATION_ACCESS_DENIED("I004", "Don't have permission to access invitation", HttpStatus.FORBIDDEN),
 
 	//TEAM_MEMBER
 	ALREADY_TEAM_MEMBER("TM0001", "Already member of team", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/controller/MatchProposalController.java
@@ -1,7 +1,6 @@
 package com.kdt.team04.domain.matches.proposal.controller;
 
 import java.util.List;
-import java.util.Optional;
 
 import javax.validation.Valid;
 
@@ -15,14 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kdt.team04.common.ApiResponse;
 import com.kdt.team04.common.config.resolver.AuthUser;
-import com.kdt.team04.common.exception.NotAuthenticationException;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.matches.proposal.dto.QueryProposalChatResponse;
 import com.kdt.team04.domain.matches.proposal.dto.request.CreateProposalRequest;
 import com.kdt.team04.domain.matches.proposal.dto.request.ReactProposalRequest;
 import com.kdt.team04.domain.matches.proposal.dto.response.ChatRoomResponse;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalChatResponse;
-import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
 import com.kdt.team04.domain.matches.proposal.service.MatchProposalService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,10 +49,11 @@ public class MatchProposalController {
 	@Operation(summary = "신청 수락 및 거절", description = "대결 공고자는 대결 신청을 수락 또는 거절 할 수 있다.")
 	@PatchMapping("/{matchId}/proposals/{id}")
 	public void proposeReact(
+		@AuthUser JwtAuthentication auth,
 		@Parameter(description = "매칭 공고 ID") @PathVariable Long matchId,
 		@Parameter(description = "매칭 신청 ID") @PathVariable Long id,
 		@RequestBody @Valid ReactProposalRequest request) {
-		matchProposalService.react(matchId, id, request.status());
+		matchProposalService.react(auth.id(), matchId, id, request.status());
 	}
 
 	@Operation(summary = "신청 목록 조회", description = "해당 대결의 신청 목록이 조회된다.")

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -152,8 +152,14 @@ public class MatchProposalService {
 	}
 
 	@Transactional
-	public MatchProposalStatus react(Long matchId, Long id, MatchProposalStatus status) {
+	public MatchProposalStatus react(Long authorId, Long matchId, Long id, MatchProposalStatus status) {
 		MatchResponse match = matchGiver.findById(matchId);
+
+		if (!Objects.equals(match.author().id(), authorId)) {
+			throw new BusinessException(ErrorCode.MATCH_ACCESS_DENIED,
+				MessageFormat.format("userId = {0}, matchId = {1}", authorId, matchId));
+		}
+
 		MatchProposal proposal = proposalRepository.findById(id)
 			.orElseThrow(() -> new BusinessException(ErrorCode.PROPOSAL_NOT_FOUND,
 				MessageFormat.format("proposalId = {0}", id)));

--- a/src/main/java/com/kdt/team04/domain/teams/teaminvitation/controller/TeamInvitationController.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teaminvitation/controller/TeamInvitationController.java
@@ -15,6 +15,7 @@ import com.kdt.team04.common.PageDto;
 import com.kdt.team04.common.config.resolver.AuthUser;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.teams.teaminvitation.dto.TeamInvitationCursor;
+import com.kdt.team04.domain.teams.teaminvitation.dto.request.TeamInvitationRefuseRequest;
 import com.kdt.team04.domain.teams.teaminvitation.dto.request.TeamInvitationRequest;
 import com.kdt.team04.domain.teams.teaminvitation.dto.response.TeamInvitationResponse;
 import com.kdt.team04.domain.teams.teaminvitation.dto.response.TeamInviteResponse;
@@ -59,10 +60,12 @@ public class TeamInvitationController {
 	@Operation(summary = "초대 거절", description = "팀 ID와 초대 ID를 받아 초대를 거절한다.")
 	@PatchMapping("/{teamId}/invitation/{invitationId}")
 	public void refuse(
+		@AuthUser JwtAuthentication auth,
 		@Parameter(description = "팀 ID") @PathVariable Long teamId,
-		@Parameter(description = "팀 초대 ID") @PathVariable Long invitationId
+		@Parameter(description = "팀 초대 ID") @PathVariable Long invitationId,
+		@RequestBody @Valid TeamInvitationRefuseRequest request
 	) {
-		teamInvitationService.refuse(teamId, invitationId);
+		teamInvitationService.refuse(auth.id(), teamId, invitationId, request);
 	}
 
 }

--- a/src/main/java/com/kdt/team04/domain/teams/teaminvitation/dto/request/TeamInvitationRefuseRequest.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teaminvitation/dto/request/TeamInvitationRefuseRequest.java
@@ -1,0 +1,11 @@
+package com.kdt.team04.domain.teams.teaminvitation.dto.request;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TeamInvitationRefuseRequest(
+	@Schema(description = "팀원 ID(고유 PK)", required = true)
+	@NotNull(message = "유저 아이디는 필수입니다.")
+	Long userId) {
+}

--- a/src/main/java/com/kdt/team04/domain/teams/teaminvitation/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teaminvitation/repository/TeamInvitationRepository.java
@@ -8,7 +8,7 @@ import com.kdt.team04.domain.teams.teaminvitation.model.InvitationStatus;
 import com.kdt.team04.domain.teams.teaminvitation.model.entity.TeamInvitation;
 
 public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long>, CustomTeamInvitationRepository {
-	boolean existsByIdAndStatus(Long teamid, InvitationStatus status);
+	boolean existsByIdAndStatus(Long teamId, InvitationStatus status);
 
 	Optional<TeamInvitation> findByIdAndTeamId(Long id, Long teamId);
 }

--- a/src/main/java/com/kdt/team04/domain/teams/teaminvitation/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teaminvitation/repository/TeamInvitationRepository.java
@@ -8,9 +8,7 @@ import com.kdt.team04.domain.teams.teaminvitation.model.InvitationStatus;
 import com.kdt.team04.domain.teams.teaminvitation.model.entity.TeamInvitation;
 
 public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long>, CustomTeamInvitationRepository {
-	boolean existsByTeamIdAndTargetIdAndStatus(Long teamId, Long targetId, InvitationStatus status);
-
-	Optional<TeamInvitation> findByTeamIdAndTargetId(Long teamId, Long targetId);
+	boolean existsByIdAndStatus(Long teamid, InvitationStatus status);
 
 	Optional<TeamInvitation> findByIdAndTeamId(Long id, Long teamId);
 }

--- a/src/main/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationGiverService.java
@@ -18,13 +18,13 @@ public class TeamInvitationGiverService {
 		this.teamInvitationRepository = teamInvitationRepository;
 	}
 
-	public boolean existsTeamInvitation(Long teamId, Long targetId, InvitationStatus status) {
-		return teamInvitationRepository.existsByTeamIdAndTargetIdAndStatus(teamId, targetId, status);
+	public boolean existsTeamInvitation(Long teamId, InvitationStatus status) {
+		return teamInvitationRepository.existsByIdAndStatus(teamId, status);
 	}
 
 	@Transactional
-	public void accept(Long teamId, Long targetId) {
-		teamInvitationRepository.findByTeamIdAndTargetId(teamId, targetId)
+	public void accept(Long id) {
+		teamInvitationRepository.findById(id)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.TEAM_INVITATION_NOT_FOUND))
 			.accept();
 	}

--- a/src/main/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationService.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationService.java
@@ -16,6 +16,7 @@ import com.kdt.team04.domain.teams.team.dto.response.TeamResponse;
 import com.kdt.team04.domain.teams.team.model.entity.Team;
 import com.kdt.team04.domain.teams.team.service.TeamService;
 import com.kdt.team04.domain.teams.teaminvitation.dto.TeamInvitationCursor;
+import com.kdt.team04.domain.teams.teaminvitation.dto.request.TeamInvitationRefuseRequest;
 import com.kdt.team04.domain.teams.teaminvitation.dto.response.TeamInviteResponse;
 import com.kdt.team04.domain.teams.teaminvitation.dto.response.TeamInvitationResponse;
 import com.kdt.team04.domain.teams.teaminvitation.model.InvitationStatus;
@@ -85,7 +86,12 @@ public class TeamInvitationService {
 	}
 
 	@Transactional
-	public void refuse(Long teamId, Long invitationId) {
+	public void refuse(Long myId, Long teamId, Long invitationId, TeamInvitationRefuseRequest request) {
+		if (!Objects.equals(request.userId(), myId)) {
+			throw new BusinessException(ErrorCode.NOT_AUTHENTICATED,
+				MessageFormat.format("초대를 거절할 권한이 없습니다 myId = {0}, targetId = {1}", myId, request.userId()));
+		}
+
 		teamInvitationRepository.findByIdAndTeamId(invitationId, teamId)
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.TEAM_INVITATION_NOT_FOUND,
 				MessageFormat.format("{0} is not team invitation id {1}", teamId, invitationId)))

--- a/src/main/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationService.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationService.java
@@ -88,8 +88,8 @@ public class TeamInvitationService {
 	@Transactional
 	public void refuse(Long myId, Long teamId, Long invitationId, TeamInvitationRefuseRequest request) {
 		if (!Objects.equals(request.userId(), myId)) {
-			throw new BusinessException(ErrorCode.NOT_AUTHENTICATED,
-				MessageFormat.format("초대를 거절할 권한이 없습니다 myId = {0}, targetId = {1}", myId, request.userId()));
+			throw new BusinessException(ErrorCode.TEAM_INVITATION_ACCESS_DENIED,
+				MessageFormat.format("do not have permission for the invitation. myId = {0}, targetId = {1}", myId, request.userId()));
 		}
 
 		teamInvitationRepository.findByIdAndTeamId(invitationId, teamId)

--- a/src/main/java/com/kdt/team04/domain/teams/teammember/controller/TeamMemberController.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teammember/controller/TeamMemberController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kdt.team04.common.config.resolver.AuthUser;
+import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.teams.teammember.dto.request.RegisterTeamMemberRequest;
 import com.kdt.team04.domain.teams.teammember.service.TeamMemberService;
 
@@ -28,8 +30,9 @@ public class TeamMemberController {
 	@Operation(summary = "초대 수락 및 팀원 등록", description = "초대 수락 후 팀에 해당 회원을 팀원으로 등록한다.")
 	@PostMapping
 	public void registerMember(@PathVariable Long teamId,
+		@AuthUser JwtAuthentication auth,
 		@RequestBody @Valid RegisterTeamMemberRequest teamMemberRegisterRequest) {
-		teamMemberService.registerTeamMember(teamId, teamMemberRegisterRequest);
+		teamMemberService.registerTeamMember(auth.id(), teamId, teamMemberRegisterRequest);
 	}
 
 }

--- a/src/main/java/com/kdt/team04/domain/teams/teammember/dto/request/RegisterTeamMemberRequest.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teammember/dto/request/RegisterTeamMemberRequest.java
@@ -7,6 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record RegisterTeamMemberRequest(
 	@Schema(description = "팀원 ID(고유 PK)", required = true)
 	@NotNull(message = "유저 아이디는 필수입니다.")
-	Long userId) {
+	Long userId,
+
+	@Schema(description = "팀 초대 ID(고유 PK)", required = true)
+	@NotNull(message = "팀 초대 아이디는 필수잆니다.")
+	Long invitationId) {
 }
 

--- a/src/main/java/com/kdt/team04/domain/teams/teammember/service/TeamMemberService.java
+++ b/src/main/java/com/kdt/team04/domain/teams/teammember/service/TeamMemberService.java
@@ -53,7 +53,7 @@ public class TeamMemberService {
 	public void registerTeamMember(Long myId, Long teamId, RegisterTeamMemberRequest request) {
 		if (!Objects.equals(request.userId(), myId)) {
 			throw new BusinessException(ErrorCode.NOT_AUTHENTICATED,
-				MessageFormat.format("초대를 수락할 권한이 없습니다. myId = {0}, targetId {1}",
+				MessageFormat.format("do not have permission for the invitation. myId = {0}, targetId = {1}",
 					myId, request.userId()));
 		}
 

--- a/src/test/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationServiceTest.java
@@ -22,6 +22,7 @@ import com.kdt.team04.common.aws.s3.S3Uploader;
 import com.kdt.team04.domain.teams.team.model.SportsCategory;
 import com.kdt.team04.domain.teams.team.dto.TeamConverter;
 import com.kdt.team04.domain.teams.team.model.entity.Team;
+import com.kdt.team04.domain.teams.teaminvitation.dto.request.TeamInvitationRefuseRequest;
 import com.kdt.team04.domain.teams.teaminvitation.dto.request.TeamInvitationRequest;
 import com.kdt.team04.domain.teams.teaminvitation.dto.response.TeamInviteResponse;
 import com.kdt.team04.domain.teams.teaminvitation.model.InvitationStatus;
@@ -197,7 +198,8 @@ class TeamInvitationServiceTest {
 		entityManager.persist(teamInvitation);
 
 		// when
-		teamInvitationService.refuse(team.getId(), teamInvitation.getId());
+		TeamInvitationRefuseRequest request = new TeamInvitationRefuseRequest(userB.getId());
+		teamInvitationService.refuse(userB.getId(), team.getId(), teamInvitation.getId(), request);
 
 		entityManager.flush();
 		entityManager.clear();
@@ -206,6 +208,41 @@ class TeamInvitationServiceTest {
 		TeamInvitation result = entityManager.find(TeamInvitation.class, teamInvitation.getId());
 		Assertions.assertThat(result.getStatus())
 			.isEqualTo(InvitationStatus.REFUSED);
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 초대를 거절할 시 권한 예외가 발생한다.")
+	void testNotAuthentication() {
+		//given
+		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		entityManager.persist(userA);
+		entityManager.persist(userB);
+
+		Team team = Team.builder()
+			.name("teamA")
+			.description("description")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(userA)
+			.build();
+		entityManager.persist(team);
+
+		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
+		entityManager.persist(teamMemberA);
+
+		TeamInvitation teamInvitation = new TeamInvitation(team, userB, InvitationStatus.WAITING);
+		entityManager.persist(teamInvitation);
+
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		TeamInvitationRefuseRequest request = new TeamInvitationRefuseRequest(userB.getId());
+
+		// then
+		Assertions.assertThatThrownBy(
+				() -> teamInvitationService.refuse(userA.getId(), team.getId(), teamInvitation.getId(), request))
+			.isInstanceOf(BusinessException.class);
 	}
 
 	@Test

--- a/src/test/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/teams/teaminvitation/service/TeamInvitationServiceTest.java
@@ -53,7 +53,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("팀 초대 성공")
-	void testInviteSuccess() {
+	void inviteSuccess() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -84,7 +84,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("이미 팀원인 유저는 초대할 수 없다.")
-	void testInviteAlreadyTeamMember() {
+	void inviteAlreadyTeamMember() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -115,7 +115,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("이미 초대 대기상태나 수락 상태인 유저에게 초대를 보낼 수 없다.")
-	void testInviteAlreadySendInviteFail() {
+	void inviteAlreadySendInviteFail() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -148,7 +148,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("팀 리더가 아닌사람은 초대할 수 없다.")
-	void testNotTeamLeaderCantInvite() {
+	void notTeamLeaderCantInvite() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -176,7 +176,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("초대를 거절할 수 있다.")
-	void testInvitationRefused() {
+	void invitationRefused() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -212,7 +212,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("다른 사용자의 초대를 거절할 시 권한 예외가 발생한다.")
-	void testNotAuthentication() {
+	void notAuthentication() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -247,7 +247,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("팀 초대 목록을 20개중 10개씩 조회한다.")
-	void testFindInvitationsLimit10() {
+	void findInvitationsLimit10() {
 		// given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -290,7 +290,7 @@ class TeamInvitationServiceTest {
 
 	@Test
 	@DisplayName("팀 초대 목록을 20개중 20개씩 조회한다.")
-	void testFindInvitationsLimit20() {
+	void findInvitationsLimit20() {
 		// given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");

--- a/src/test/java/com/kdt/team04/domain/teams/teammember/controller/TeamMemberControllerTest.java
+++ b/src/test/java/com/kdt/team04/domain/teams/teammember/controller/TeamMemberControllerTest.java
@@ -35,6 +35,7 @@ public class TeamMemberControllerTest {
 	private final static String BASE_END_POINT = "/api/teams";
 	private final static Long DEFAULT_INVITATION_MEMBER_ID = 1L;
 	private final static Long DEFAULT_TEAM_ID = 2L;
+	private final static Long DEFAULT_INVITATION_ID = 3L;
 
 	@Autowired
 	MockMvc mockMvc;
@@ -65,7 +66,7 @@ public class TeamMemberControllerTest {
 		).andDo(print());
 
 		// then
-		verify(teamMemberService, times(0)).registerTeamMember(DEFAULT_TEAM_ID, request);
+		verify(teamMemberService, times(0)).registerTeamMember(null, DEFAULT_TEAM_ID, request);
 		resultActions.andExpect(status().isBadRequest());
 	}
 
@@ -73,7 +74,8 @@ public class TeamMemberControllerTest {
 	@DisplayName("초대 받은 사용자라면 팀원에 등록 후 200 상태코드를 반환한다.")
 	void successTeamMemberRegister() throws Exception {
 		// given
-		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(DEFAULT_INVITATION_MEMBER_ID);
+		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(DEFAULT_INVITATION_MEMBER_ID,
+			DEFAULT_INVITATION_ID);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(
@@ -83,7 +85,7 @@ public class TeamMemberControllerTest {
 		).andDo(print());
 
 		// then
-		verify(teamMemberService, times(1)).registerTeamMember(DEFAULT_TEAM_ID, request);
+		verify(teamMemberService, times(1)).registerTeamMember(DEFAULT_INVITATION_MEMBER_ID, DEFAULT_TEAM_ID, request);
 		resultActions.andExpect(status().isOk());
 	}
 
@@ -93,11 +95,12 @@ public class TeamMemberControllerTest {
 		// given
 		ErrorCode errorCode = ErrorCode.ALREADY_TEAM_MEMBER;
 
-		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(DEFAULT_INVITATION_MEMBER_ID);
+		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(DEFAULT_INVITATION_MEMBER_ID,
+			DEFAULT_INVITATION_ID);
 		ErrorResponse<ErrorCode> response = new ErrorResponse<>(errorCode);
 
 		doThrow(new BusinessException(errorCode)).when(teamMemberService)
-			.registerTeamMember(DEFAULT_TEAM_ID, request);
+			.registerTeamMember(DEFAULT_INVITATION_MEMBER_ID, DEFAULT_TEAM_ID, request);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(
@@ -107,7 +110,7 @@ public class TeamMemberControllerTest {
 		).andDo(print());
 
 		// then
-		verify(teamMemberService, times(1)).registerTeamMember(DEFAULT_TEAM_ID, request);
+		verify(teamMemberService, times(1)).registerTeamMember(DEFAULT_INVITATION_MEMBER_ID, DEFAULT_TEAM_ID, request);
 
 		resultActions.andExpect(status().isBadRequest())
 			.andExpect(content().string(objectMapper.writeValueAsString(response)));
@@ -119,10 +122,12 @@ public class TeamMemberControllerTest {
 		// given
 		ErrorCode errorCode = ErrorCode.INVALID_TEAM_INVITATION;
 
-		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(DEFAULT_INVITATION_MEMBER_ID);
+		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(DEFAULT_INVITATION_MEMBER_ID,
+			DEFAULT_INVITATION_ID);
 		ErrorResponse<ErrorCode> response = new ErrorResponse<>(errorCode);
 
-		doThrow(new BusinessException(errorCode)).when(teamMemberService).registerTeamMember(DEFAULT_TEAM_ID, request);
+		doThrow(new BusinessException(errorCode)).when(teamMemberService)
+			.registerTeamMember(DEFAULT_INVITATION_MEMBER_ID, DEFAULT_TEAM_ID, request);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(
@@ -132,7 +137,7 @@ public class TeamMemberControllerTest {
 		).andDo(print());
 
 		// then
-		verify(teamMemberService, times(1)).registerTeamMember(DEFAULT_TEAM_ID, request);
+		verify(teamMemberService, times(1)).registerTeamMember(DEFAULT_INVITATION_MEMBER_ID, DEFAULT_TEAM_ID, request);
 
 		resultActions.andExpect(status().isBadRequest())
 			.andExpect(content().string(objectMapper.writeValueAsString(response)));

--- a/src/test/java/com/kdt/team04/domain/teams/teammember/service/TeamMemberServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/teams/teammember/service/TeamMemberServiceTest.java
@@ -40,7 +40,7 @@ class TeamMemberServiceTest {
 
 	@Test
 	@DisplayName("팀원 등록에 성공한다.")
-	void testRegisterMember() {
+	void registerMember() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -73,7 +73,7 @@ class TeamMemberServiceTest {
 
 	@Test
 	@DisplayName("다른 사용자의 초대를 수락할 시 권한 예외가 발생한다.")
-	void testNotAuthentication() {
+	void notAuthentication() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -106,7 +106,7 @@ class TeamMemberServiceTest {
 
 	@Test
 	@DisplayName("이미 등록된 팀원은 등록에 실패한다.")
-	void testAlreadyMember() {
+	void alreadyMember() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
@@ -139,7 +139,7 @@ class TeamMemberServiceTest {
 
 	@Test
 	@DisplayName("초대 상태가 WAITING 상태가 아니라면 등록에 실패한다.")
-	void testInvalidInvitation() {
+	void invalidInvitation() {
 		//given
 		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
 		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");

--- a/src/test/java/com/kdt/team04/domain/teams/teammember/service/TeamMemberServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/teams/teammember/service/TeamMemberServiceTest.java
@@ -11,16 +11,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.kdt.team04.common.exception.BusinessException;
 import com.kdt.team04.common.aws.s3.S3Uploader;
+import com.kdt.team04.common.exception.BusinessException;
 import com.kdt.team04.domain.teams.team.model.SportsCategory;
 import com.kdt.team04.domain.teams.team.model.entity.Team;
 import com.kdt.team04.domain.teams.teaminvitation.model.InvitationStatus;
 import com.kdt.team04.domain.teams.teaminvitation.model.entity.TeamInvitation;
 import com.kdt.team04.domain.teams.teammember.dto.request.RegisterTeamMemberRequest;
-import com.kdt.team04.domain.teams.teammember.model.entity.TeamMember;
 import com.kdt.team04.domain.teams.teammember.model.TeamMemberRole;
-import com.kdt.team04.domain.teams.teammember.service.TeamMemberService;
+import com.kdt.team04.domain.teams.teammember.model.entity.TeamMember;
 import com.kdt.team04.domain.user.entity.User;
 
 @SpringBootTest
@@ -60,14 +59,49 @@ class TeamMemberServiceTest {
 		entityManager.persist(teamMemberA);
 		TeamInvitation teamInvitationA = new TeamInvitation(team, userB, InvitationStatus.WAITING);
 		entityManager.persist(teamInvitationA);
-		entityManager.flush();
 
 		// when
-		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(userB.getId());
-		teamMemberService.registerTeamMember(team.getId(), request);
+		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(userB.getId(), teamInvitationA.getId());
+		teamMemberService.registerTeamMember(userB.getId(), team.getId(), request);
+
+		entityManager.flush();
+		entityManager.clear();
 
 		// then
 		Assertions.assertThat(teamMemberService.existsTeamMember(team.getId(), userB.getId())).isTrue();
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 초대를 수락할 시 권한 예외가 발생한다.")
+	void testNotAuthentication() {
+		//given
+		User userA = new User("test1234", "nickname", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		User userB = new User("test4567", "nickname2", "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.");
+		entityManager.persist(userA);
+		entityManager.persist(userB);
+
+		Team team = Team.builder()
+			.name("teamA")
+			.description("description")
+			.sportsCategory(SportsCategory.BADMINTON)
+			.leader(userA)
+			.build();
+		entityManager.persist(team);
+
+		TeamMember teamMemberA = new TeamMember(team, userA, TeamMemberRole.LEADER);
+		entityManager.persist(teamMemberA);
+
+		TeamInvitation teamInvitation = new TeamInvitation(team, userB, InvitationStatus.WAITING);
+		entityManager.persist(teamInvitation);
+		entityManager.flush();
+		entityManager.clear();
+
+		// when
+		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(userB.getId(), teamInvitation.getId());
+
+		// then
+		Assertions.assertThatThrownBy(() -> teamMemberService.registerTeamMember(userA.getId(), team.getId(), request))
+			.isInstanceOf(BusinessException.class);
 	}
 
 	@Test
@@ -96,10 +130,10 @@ class TeamMemberServiceTest {
 		entityManager.flush();
 
 		// when
-		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(userB.getId());
+		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(userB.getId(), teamMemberA.getId());
 
 		// then
-		Assertions.assertThatThrownBy(() -> teamMemberService.registerTeamMember(team.getId(), request))
+		Assertions.assertThatThrownBy(() -> teamMemberService.registerTeamMember(userB.getId(), team.getId(), request))
 			.isInstanceOf(BusinessException.class);
 	}
 
@@ -128,10 +162,10 @@ class TeamMemberServiceTest {
 		entityManager.persist(teamInvitationA);
 
 		// when
-		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(userB.getId());
+		RegisterTeamMemberRequest request = new RegisterTeamMemberRequest(userB.getId(), teamInvitationA.getId());
 
 		// then
-		Assertions.assertThatThrownBy(() -> teamMemberService.registerTeamMember(team.getId(), request))
+		Assertions.assertThatThrownBy(() -> teamMemberService.registerTeamMember(userB.getId(), team.getId(), request))
 			.isInstanceOf(BusinessException.class);
 	}
 


### PR DESCRIPTION
## ✅  작업 단위

### 팀 초대 중복을 허용함에 있어서 발생했던 버그들을 수정했습니다.
  * 초대가 2개 이상일 경우 수락이 안되는 부분 -> 해결
    * 팀 초대 수락 API요청 시 Body에 invitationId를 함께 받아서 해결하도록 프론트와 협의를 했습니다.

### 자신만 초대를 거절할 수 있고 수락할 수 있다.
  * 수정되기 전 내가 아닌 다른 사람이 거절 및 수락을 할 수 있는 문제점도 보여서 해당 부분을 검증하는 코드를 추가했습니다.

## 🤔 고민 했던 부분

### 자신만 초대를 거절할 수 있는 검증 로직
* 팀 초대 거절 API 에서  현재 로그인한 유저와 일치하는지 확인하기 위해서 userId(초대대상 유저아이디)를 받아서 검증을 처리할지 ? DB에서 직접 초대 아이디를 통해 가져와서 비교할지? 고민이 되었습니다.
* 앤드포인트를 api/teams/{teamId}/invitations/xxx  변경하여  팀 초대 수락과 동일하게 초대 id와 target 유저 아이디를 body에서 받아야할지, 기존 앤드포인트에다가 추가적으로 Body에 userId만 받을지,  애초에 받지 않고 초대 아이디를 통해 DB에서 조회해 와서 아이디를 검증할지, 여러가지 방법이 고민이 되었습니다.

  * 저의 개인적인 생각으로 프론트에 전달한 값을 백엔드에서도 잘 받아서 활용해야 한다는 생각을 가지고 있어서 기존 앤드포인트를 유지하고 DTO를 하나 만들어서 Body에 유저 아이디를 받도록 수정을 했습니다. 혹시 저의 생각이 틀렸거나 더 좋은 의견이 있으시다면 말씀해주시면 감사드리겠습니다 !

## 🔊 HELP !!
