### PR TITLE
[Dk-372] 매치 리스트 응답 수정

### DIFF
--- a/src/main/java/com/kdt/team04/common/PageDto.java
+++ b/src/main/java/com/kdt/team04/common/PageDto.java
@@ -101,6 +101,9 @@ public class PageDto {
 		@Parameter(description = "매칭 상태")
 		private MatchStatus status;
 
+		@Parameter(description = "회원 ID(고유 PK) userID 입력 시 distance는 무시 된다.")
+		private Long userId;
+
 		@Min(5)
 		@Max(40)
 		@Parameter(description = "검색 거리, 5 ~ 40까지 가능")
@@ -159,6 +162,14 @@ public class PageDto {
 
 		public void setCategory(SportsCategory category) {
 			this.category = category;
+		}
+
+		public Long getUserId() {
+			return this.userId;
+		}
+
+		public void setUserId(Long userId) {
+			this.userId = userId;
 		}
 
 		public Double getDistance() {

--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -59,7 +59,7 @@ public enum ErrorCode {
 	PROPOSAL_INVALID_REACT("MP0005", "Invalid react", HttpStatus.BAD_REQUEST),
 	PROPOSAL_ACCESS_DENIED("MP0006", "Don't have permission to access match proposal", HttpStatus.FORBIDDEN),
 	PROPOSAL_ALREADY_REQUESTED("MP0007", "Already requested", HttpStatus.BAD_REQUEST),
-	TOO_FAR_TO_REQUEST("MP00008", "This Match is too far from you" , HttpStatus.BAD_REQUEST),
+	PROPOSAL_TOO_FAR_TO_REQUEST("MP0008", "This Match is too far from you" , HttpStatus.BAD_REQUEST),
 
 	//MATCH_CHAT
 	MATCH_CHAT_NOT_CORRECT_CHAT_PARTNER("MC0002", "The chat partner is incorrect.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
+++ b/src/main/java/com/kdt/team04/common/exception/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
 	PROPOSAL_INVALID_REACT("MP0005", "Invalid react", HttpStatus.BAD_REQUEST),
 	PROPOSAL_ACCESS_DENIED("MP0006", "Don't have permission to access match proposal", HttpStatus.FORBIDDEN),
 	PROPOSAL_ALREADY_REQUESTED("MP0007", "Already requested", HttpStatus.BAD_REQUEST),
+	TOO_FAR_TO_REQUEST("MP00008", "This Match is too far from you" , HttpStatus.BAD_REQUEST),
 
 	//MATCH_CHAT
 	MATCH_CHAT_NOT_CORRECT_CHAT_PARTNER("MC0002", "The chat partner is incorrect.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchConverter.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/dto/MatchConverter.java
@@ -25,6 +25,7 @@ public class MatchConverter {
 			.matchDate(match.getMatchDate())
 			.matchType(match.getMatchType())
 			.content(match.getContent())
+			.location(match.getLocation())
 			.build();
 	}
 
@@ -44,6 +45,7 @@ public class MatchConverter {
 			.matchType(match.getMatchType())
 			.content(match.getContent())
 			.proposer(proposer)
+			.location(match.getLocation())
 			.build();
 	}
 
@@ -63,6 +65,7 @@ public class MatchConverter {
 			.matchDate(match.getMatchDate())
 			.matchType(match.getMatchType())
 			.content(match.getContent())
+			.location(match.getLocation())
 			.build();
 	}
 
@@ -84,6 +87,7 @@ public class MatchConverter {
 			.matchType(match.getMatchType())
 			.content(match.getContent())
 			.proposer(proposer)
+			.location(match.getLocation())
 			.build();
 	}
 
@@ -98,6 +102,7 @@ public class MatchConverter {
 			.matchDate(matchResponse.matchDate())
 			.matchType(matchResponse.matchType())
 			.participants(matchResponse.participants())
+			.location(matchResponse.location())
 			.build();
 
 	}
@@ -114,6 +119,7 @@ public class MatchConverter {
 			.matchDate(matchResponse.matchDate())
 			.matchType(matchResponse.matchType())
 			.participants(matchResponse.participants())
+			.location(matchResponse.location())
 			.build();
 
 	}

--- a/src/main/java/com/kdt/team04/domain/matches/match/dto/response/MatchListViewResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/dto/response/MatchListViewResponse.java
@@ -1,5 +1,6 @@
 package com.kdt.team04.domain.matches.match.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -24,8 +25,17 @@ public record MatchListViewResponse(
 	@Schema(description = "매칭 글 내용")
 	String content,
 
+	@Schema(description = "작성자 ID(고유 PK)")
+	Long authorId,
+
+	@Schema(description = "작성자 닉네임")
+	String authorNickname,
+
 	@Schema(description = "나와의 거리")
 	Double distance,
+
+	@Schema(description = "원하는 경기 일자")
+	LocalDate matchDate,
 
 	@Schema(description = "작성 일자")
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")

--- a/src/main/java/com/kdt/team04/domain/matches/match/dto/response/MatchResponse.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/dto/response/MatchResponse.java
@@ -3,12 +3,14 @@ package com.kdt.team04.domain.matches.match.dto.response;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kdt.team04.domain.matches.match.model.MatchStatus;
 import com.kdt.team04.domain.matches.match.model.MatchType;
 import com.kdt.team04.domain.matches.proposal.dto.response.ProposalSimpleResponse;
 import com.kdt.team04.domain.teams.team.model.SportsCategory;
 import com.kdt.team04.domain.teams.team.dto.response.TeamSimpleResponse;
 import com.kdt.team04.domain.user.dto.response.AuthorResponse;
+import com.kdt.team04.domain.user.entity.Location;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -46,6 +48,10 @@ public record MatchResponse(
 	String content,
 
 	@Schema(description = "매칭 신청 정보(로그인한 사용자가 신청했다면 정보 포함 | 아니라면 null 반환)")
-	Optional<ProposalSimpleResponse> proposer
+	Optional<ProposalSimpleResponse> proposer,
+
+	@Schema(description = "매치 작성 위치 정보")
+	@JsonIgnore
+	Location location
 ) {
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/repository/CustomMatchRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/repository/CustomMatchRepository.java
@@ -7,4 +7,6 @@ import com.kdt.team04.domain.matches.match.dto.response.MatchListViewResponse;
 public interface CustomMatchRepository {
 	PageDto.CursorResponse<MatchListViewResponse, MatchPagingCursor> findByLocationPaging(Double latitude,
 		Double longitude, PageDto.MatchCursorPageRequest pageRequest);
+
+	Double getDistance(Double latitude, Double longitude, Long matchId);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/repository/CustomMatchRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/repository/CustomMatchRepositoryImpl.java
@@ -126,4 +126,16 @@ public class CustomMatchRepositoryImpl implements CustomMatchRepository {
 			.fetchFirst() != null;
 	}
 
+	@Override
+	public Double getDistance(Double latitude, Double longitude, Long matchId) {
+		NumberExpression<Double> distanceExpression = asNumber(6371.0)
+			.multiply(acos(cos(radians(asNumber(latitude))).multiply(cos(radians(match.location.latitude)))
+				.multiply(cos(radians(match.location.longitude).subtract(radians(asNumber(longitude)))))
+				.add(sin(radians(asNumber(latitude))).multiply(sin(radians(match.location.latitude))))));
+
+		return jpaQueryFactory.select(distanceExpression)
+			.from(match)
+			.where(match.id.eq(matchId))
+			.fetchOne();
+	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/match/repository/CustomMatchRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/repository/CustomMatchRepositoryImpl.java
@@ -33,8 +33,7 @@ public class CustomMatchRepositoryImpl implements CustomMatchRepository {
 	}
 
 	public PageDto.CursorResponse<MatchListViewResponse, MatchPagingCursor> findByLocationPaging(
-		Double latitude,
-		Double longitude, PageDto.MatchCursorPageRequest pageRequest) {
+		Double latitude, Double longitude, PageDto.MatchCursorPageRequest pageRequest) {
 		Double distance = pageRequest.getDistance();
 		Integer size = pageRequest.getSize();
 		SportsCategory category = pageRequest.getCategory();
@@ -67,6 +66,7 @@ public class CustomMatchRepositoryImpl implements CustomMatchRepository {
 			.orElse(null);
 
 		BooleanExpression cursorCondition = null;
+
 		if (createdAt != null && id != null) {
 			cursorCondition = match.createdAt.lt(asDateTime(createdAt))
 				.or(asDateTime(createdAt).eq(match.createdAt).and(asNumber(match.id).lt(id)));

--- a/src/main/java/com/kdt/team04/domain/matches/match/service/MatchGiverService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/service/MatchGiverService.java
@@ -12,8 +12,8 @@ import com.kdt.team04.common.exception.ErrorCode;
 import com.kdt.team04.domain.matches.match.dto.MatchConverter;
 import com.kdt.team04.domain.matches.match.dto.response.MatchAuthorResponse;
 import com.kdt.team04.domain.matches.match.dto.response.MatchResponse;
-import com.kdt.team04.domain.matches.match.model.entity.Match;
 import com.kdt.team04.domain.matches.match.model.MatchStatus;
+import com.kdt.team04.domain.matches.match.model.entity.Match;
 import com.kdt.team04.domain.matches.match.repository.MatchRepository;
 import com.kdt.team04.domain.teams.team.dto.response.TeamSimpleResponse;
 import com.kdt.team04.domain.teams.team.model.entity.Team;
@@ -105,5 +105,9 @@ public class MatchGiverService {
 			team.getSportsCategory(), team.getLogoImageUrl());
 
 		return matchConverter.toMatchResponse(match, author, teamResponse);
+	}
+
+	public Double getDistance(Double latitude, Double longitude, Long matchId) {
+		return matchRepository.getDistance(latitude, longitude, matchId);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -106,7 +106,11 @@ public class MatchProposalService {
 		UserResponse proposerResponse = userService.findById(proposerId);
 		User proposer = userConverter.toUser(proposerResponse);
 
-		verifyDistance(proposerResponse, matchResponse);
+		Double distance = matchGiver.getDistance(
+			proposerResponse.userSettings().getLocation().getLatitude(),
+			proposerResponse.userSettings().getLocation().getLongitude(),
+			matchResponse.id());
+		verifyDistance(proposerResponse, matchResponse, distance);
 
 		MatchProposal matchProposal = matchResponse.matchType() == MatchType.TEAM_MATCH ?
 			teamProposalCreate(author, proposer, matchResponse, request) :
@@ -154,10 +158,10 @@ public class MatchProposalService {
 			.build();
 	}
 
-	private void verifyDistance(UserResponse proposer, MatchResponse match) {
+	private void verifyDistance(UserResponse proposer, MatchResponse match, Double distance) {
 		Location proposerLocation = proposer.userSettings().getLocation();
-		if (matchGiver.getDistance(proposerLocation.getLatitude(), proposerLocation.getLongitude(), match.id()) > 40) {
-			throw new BusinessException(ErrorCode.TOO_FAR_TO_REQUEST,
+		if (distance > 40) {
+			throw new BusinessException(ErrorCode.PROPOSAL_TOO_FAR_TO_REQUEST,
 				MessageFormat.format(
 					"User is too far from Match, User ID, Location = ({0}, {1}), match ID, Location = ({2}, {3})",
 					proposer.id(),

--- a/src/main/java/com/kdt/team04/domain/user/entity/Location.java
+++ b/src/main/java/com/kdt/team04/domain/user/entity/Location.java
@@ -4,6 +4,9 @@ import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Embeddable;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 @Embeddable
 @Access(AccessType.FIELD)
 public class Location {
@@ -26,4 +29,11 @@ public class Location {
 		return this.longitude;
 	}
 
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("latitude", latitude)
+			.append("longitude", longitude)
+			.toString();
+	}
 }

--- a/src/test/java/com/kdt/team04/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/kdt/team04/domain/auth/service/AuthServiceTest.java
@@ -60,8 +60,16 @@ class AuthServiceTest {
 		//given
 		String password = "@Test1234";
 		String encodedPassword = "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.";
-		UserResponse userResponse = new UserResponse(1L, "test00", encodedPassword, "nickname", null,
-			"test00@gmail.com", null, Role.USER);
+		UserResponse userResponse = new UserResponse(1L,
+			"test00",
+			encodedPassword,
+			"nickname",
+			null,
+			"test00@gmail.com",
+			null,
+			Role.USER
+		);
+
 		List<GrantedAuthority> authorities = new ArrayList<>(
 			Collections.singleton(new SimpleGrantedAuthority("USER")));
 		Jwt.Claims claims = Jwt.Claims.builder()
@@ -102,8 +110,15 @@ class AuthServiceTest {
 		//given
 		String password = "@Test1234";
 		String encodedPassword = "$2a$12$JB1zYmj1TfoylCds8Tt5ue//BQTWE2xO5HZn.MjZcpo.z.7LKagZ.";
-		UserResponse userResponse = new UserResponse(1L, "test00", encodedPassword, "nickname", null,
-			"test00@gmail.com", null, Role.USER);
+		UserResponse userResponse = new UserResponse(1L,
+			"test00",
+			encodedPassword,
+			"nickname",
+			null,
+			"test00@gmail.com",
+			null,
+			Role.USER
+		);
 		given(userService.findByUsername(userResponse.username())).willReturn(userResponse);
 		given(passwordEncoder.matches(password, encodedPassword)).willReturn(false);
 		//when, then

--- a/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
+++ b/src/test/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalServiceIntegrationTest.java
@@ -40,7 +40,6 @@ import com.kdt.team04.domain.teams.team.model.SportsCategory;
 import com.kdt.team04.domain.teams.team.model.entity.Team;
 import com.kdt.team04.domain.teams.teammember.model.TeamMemberRole;
 import com.kdt.team04.domain.teams.teammember.model.entity.TeamMember;
-import com.kdt.team04.domain.teams.teammember.model.entity.TeamMember;
 import com.kdt.team04.domain.user.dto.response.ChatTargetProfileResponse;
 import com.kdt.team04.domain.user.entity.User;
 
@@ -68,7 +67,10 @@ class MatchProposalServiceIntegrationTest {
 	void testIndividualCreateSuccess() {
 		//given
 		User author = new User("author", "author", "aA1234!");
+		author.updateSettings(127.1554531, 37.6139816, 40);
 		User proposer = new User("proposer", "proposer", "aA1234!");
+		proposer.updateSettings(127.1554531, 37.6139816, 40);
+
 		entityManager.persist(author);
 		entityManager.persist(proposer);
 
@@ -81,6 +83,7 @@ class MatchProposalServiceIntegrationTest {
 			.user(author)
 			.sportsCategory(SportsCategory.BADMINTON)
 			.content("content")
+			.location(author.getUserSettings().getLocation())
 			.build();
 		entityManager.persist(match);
 		CreateProposalRequest request = new CreateProposalRequest(null, "개인전 신청합니다.");
@@ -97,6 +100,7 @@ class MatchProposalServiceIntegrationTest {
 	void testTeamProposerCreateSuccess() {
 		//given
 		User author = new User("author", "author", "aA1234!");
+		author.updateSettings(127.1554531, 37.6139816, 40);
 
 		entityManager.persist(author);
 
@@ -110,14 +114,13 @@ class MatchProposalServiceIntegrationTest {
 		entityManager.persist(authorTeam);
 
 		User proposer = new User("proposer", "proposer", "aA1234!");
+		proposer.updateSettings(127.1554531, 37.6139816, 40);
 		User user1 = new User("member1", "member1", "password");
 		User user2 = new User("member2", "member2", "password");
 
 		entityManager.persist(proposer);
 		entityManager.persist(user1);
 		entityManager.persist(user2);
-
-		proposer.updateSettings(1.1, 1.2, 10);
 
 		Team proposerTeam = Team.builder()
 			.name("proposer")
@@ -141,6 +144,7 @@ class MatchProposalServiceIntegrationTest {
 			.team(authorTeam)
 			.sportsCategory(SportsCategory.BADMINTON)
 			.content("content")
+			.location(author.getUserSettings().getLocation())
 			.build();
 
 		entityManager.persist(match);
@@ -263,6 +267,7 @@ class MatchProposalServiceIntegrationTest {
 	void testTeamProposerCreateFailByTeamMember() {
 		//given
 		User author = new User("author", "author", "aA1234!");
+		author.updateSettings(127.1554531, 37.6139816, 40);
 
 		entityManager.persist(author);
 
@@ -300,6 +305,7 @@ class MatchProposalServiceIntegrationTest {
 			.team(authorTeam)
 			.sportsCategory(SportsCategory.BADMINTON)
 			.content("content")
+			.location(author.getUserSettings().getLocation())
 			.build();
 
 		entityManager.persist(match);
@@ -317,7 +323,9 @@ class MatchProposalServiceIntegrationTest {
 	void testTeamProposerCreateFail() {
 		//given
 		User author = new User("author", "author", "aA1234!");
+		author.updateSettings(127.1554531, 37.6139816, 40);
 		User proposer = new User("proposer", "proposer", "aA1234!");
+		proposer.updateSettings(127.1554531, 37.6139816, 40);
 
 		entityManager.persist(author);
 		entityManager.persist(proposer);
@@ -348,6 +356,7 @@ class MatchProposalServiceIntegrationTest {
 			.team(authorTeam)
 			.sportsCategory(SportsCategory.BADMINTON)
 			.content("content")
+			.location(author.getUserSettings().getLocation())
 			.build();
 		entityManager.persist(match);
 		CreateProposalRequest request = new CreateProposalRequest(null, "팀전 신청합니다.");
@@ -421,9 +430,14 @@ class MatchProposalServiceIntegrationTest {
 
 		List<ChatRoomResponse> expected = new ArrayList<>();
 		expected.add(new ChatRoomResponse(proposal2.getId(), proposal2.getContent(), new ChatTargetProfileResponse(
-			BigInteger.valueOf(target2.getId()), target2.getNickname()), new LastChatResponse(chat.getContent()), proposal2.getCreatedAt()));
-		expected.add(new ChatRoomResponse(proposal3.getId(), proposal3.getContent(), new ChatTargetProfileResponse(BigInteger.valueOf(target3.getId()), target3.getNickname()), null, proposal3.getCreatedAt()));
-		expected.add(new ChatRoomResponse(proposal1.getId(), proposal1.getContent(), new ChatTargetProfileResponse(BigInteger.valueOf(target1.getId()), target1.getNickname()), null, proposal1.getCreatedAt()));
+			BigInteger.valueOf(target2.getId()), target2.getNickname()), new LastChatResponse(chat.getContent()),
+			proposal2.getCreatedAt()));
+		expected.add(new ChatRoomResponse(proposal3.getId(), proposal3.getContent(),
+			new ChatTargetProfileResponse(BigInteger.valueOf(target3.getId()), target3.getNickname()), null,
+			proposal3.getCreatedAt()));
+		expected.add(new ChatRoomResponse(proposal1.getId(), proposal1.getContent(),
+			new ChatTargetProfileResponse(BigInteger.valueOf(target1.getId()), target1.getNickname()), null,
+			proposal1.getCreatedAt()));
 
 		//when
 		matchProposalService.findAllProposalChats(match.getId(), author.getId());


### PR DESCRIPTION
## ✅  작업 단위

- [[DK-372] feat: 유저의 글 모아보기를 위한 매치 리스트 조회 파라미터에 userId 추가, 매치 작성자 정보 포함 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/acfd48d481a6f4e303e5992466434e8238558ac6)
  - 추후에 유저의 글 모아보기 기능이 필요해보여 MatchList 페이징방식 조회에 조금 더 기능을 추가 했습니다.
  - userID를 기입하면 distance와 무관하게 조회됩니다 (유저의 글 모아보기를 위함)
  - userID를 기입하지 않으면 distance 파라미터가 활성화 됩니다. (메인 페이지의 매치 리스트 조회를 위함)
  - 매치 리스트 조회 시 작성자 정보가 필요해보여 아이디와 닉네임을 추가 했습니다.
    - 팀전이면 팀정보를 표시하면 좋겠지만? 일단은... 이렇게...

- [[DK-372] feat: 매치 신청 시 거리가 40km 초과라면 신청 불가 검증 로직 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/8b88428207455229b9d35efca88fd578e13ca322)
  - 유저의 글 모아보기를 사용한다면 거리 상관없이 유저의 글이 보여질 수 있습니다. 그렇게 된다면 혹시라도 거리와 상관없이 무분별한 신청이 우려되어 매칭 신청시 최대 40km로 제한해 초과된다면 TOO_FAR_TO_REQUEST 에러를 발생시킵니다.
  
- [[DK-372] test: 변경에 따른 test 코드 수정(위치 정보 필요)](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/adcca9ba96dec8cb54169d9345bffda529310a4c)
  - 테스트 코드에 유저, 글에 대한 위치 정보가 필요해 추가해줬습니다.



[DK-372]: https://insta-kkyu.atlassian.net/browse/DK-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-372]: https://insta-kkyu.atlassian.net/browse/DK-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-372]: https://insta-kkyu.atlassian.net/browse/DK-372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ