### PR TITLE
[DK-454] feat:  전적 조회 API 추가

### DIFF
--- a/src/main/java/com/kdt/team04/domain/matches/review/controller/MatchRecordController.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/controller/MatchRecordController.java
@@ -2,6 +2,8 @@ package com.kdt.team04.domain.matches.review.controller;
 
 import javax.validation.Valid;
 
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,14 +13,16 @@ import org.springframework.web.bind.annotation.RestController;
 import com.kdt.team04.common.config.resolver.AuthUser;
 import com.kdt.team04.common.security.jwt.JwtAuthentication;
 import com.kdt.team04.domain.matches.review.dto.request.CreateMatchRecordRequest;
+import com.kdt.team04.domain.matches.review.dto.response.MatchRecordTotalResponse;
 import com.kdt.team04.domain.matches.review.service.MatchRecordService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
 
 @Tag(name = "경기 결과 API")
 @RestController
-@RequestMapping("/api/matches/{id}/records")
+@RequestMapping("/api/matches")
 public class MatchRecordController {
 
 	private final MatchRecordService matchRecordService;
@@ -28,12 +32,20 @@ public class MatchRecordController {
 	}
 
 	@Operation(summary = "경기 결과 등록", description = "경기 결과를 등록한다.")
-	@PostMapping
+	@PostMapping("/{id}/records")
 	public void endGame(
 		@AuthUser JwtAuthentication authentication,
 		@PathVariable Long id,
 		@Valid @RequestBody CreateMatchRecordRequest request
 	) {
 		matchRecordService.endGame(id, request.proposalId(), request.result(), authentication.id());
+	}
+
+	@Operation(summary = "경기 전적 조회", description = "사용자 또는 팀의 전적 조회를 합니다.")
+	@GetMapping("/records")
+	public MatchRecordTotalResponse getRecords(
+		@Valid @ParameterObject QueryMatchRecordRequest request
+	) {
+		return matchRecordService.findMatchRecordTotal(request);
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/review/controller/QueryMatchRecordRequest.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/controller/QueryMatchRecordRequest.java
@@ -1,0 +1,24 @@
+package com.kdt.team04.domain.matches.review.controller;
+
+import javax.validation.constraints.AssertTrue;
+
+import com.kdt.team04.domain.teams.team.model.SportsCategory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record QueryMatchRecordRequest(
+	@Schema(description = "스포츠 종목(값/설명) - BADMINTON/배드민턴, SOCCER/축구, BASEBALL/야구")
+	SportsCategory sportsCategory,
+
+	@Schema(description = "회원 ID(고유 PK)")
+	Long userId,
+
+	@Schema(description = "팀 ID(고유 PK)")
+	Long teamId
+) {
+
+	@AssertTrue
+	boolean isValidIdInput() {
+		return userId != null || teamId != null;
+	}
+}

--- a/src/main/java/com/kdt/team04/domain/matches/review/repository/CustomMatchRecordRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/repository/CustomMatchRecordRepository.java
@@ -1,7 +1,10 @@
 package com.kdt.team04.domain.matches.review.repository;
 
+import com.kdt.team04.domain.matches.review.controller.QueryMatchRecordRequest;
 import com.kdt.team04.domain.matches.review.dto.response.MatchRecordTotalResponse;
 
 public interface CustomMatchRecordRepository {
 	MatchRecordTotalResponse getTeamTotalCount(Long teamId);
+
+	MatchRecordTotalResponse getTotalCount(QueryMatchRecordRequest request);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/review/repository/CustomMatchRecordRepositoryImpl.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/repository/CustomMatchRecordRepositoryImpl.java
@@ -2,11 +2,16 @@ package com.kdt.team04.domain.matches.review.repository;
 
 import static com.kdt.team04.domain.matches.review.model.entity.QMatchRecord.matchRecord;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
+import com.kdt.team04.domain.matches.review.controller.QueryMatchRecordRequest;
 import com.kdt.team04.domain.matches.review.dto.response.MatchRecordTotalResponse;
 import com.kdt.team04.domain.matches.review.model.MatchRecordValue;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
@@ -28,6 +33,31 @@ public class CustomMatchRecordRepositoryImpl implements CustomMatchRecordReposit
 			))
 			.from(matchRecord)
 			.where(matchRecord.team.id.eq(teamId))
+			.fetchOne();
+	}
+
+	@Override
+	public MatchRecordTotalResponse getTotalCount(QueryMatchRecordRequest request) {
+		BooleanExpression userIdEq = Optional.ofNullable(request.userId())
+			.map(matchRecord.user.id::eq)
+			.orElse(null);
+		BooleanExpression teamIdEq = Optional.ofNullable(request.teamId())
+			.map(matchRecord.team.id::eq)
+			.orElse(userIdEq);
+		BooleanExpression sportsCategoryEq = Optional.ofNullable(request.sportsCategory())
+			.map(matchRecord.match.sportsCategory::eq)
+			.orElse(null);
+
+		BooleanBuilder where = new BooleanBuilder();
+
+		return queryFactory
+			.select(Projections.constructor(MatchRecordTotalResponse.class,
+				matchRecord.result.when(MatchRecordValue.WIN).then(1).otherwise(0).sum(),
+				matchRecord.result.when(MatchRecordValue.DRAW).then(1).otherwise(0).sum(),
+				matchRecord.result.when(MatchRecordValue.LOSE).then(1).otherwise(0).sum()
+			))
+			.from(matchRecord)
+			.where(where.and(teamIdEq).and(sportsCategoryEq))
 			.fetchOne();
 	}
 }

--- a/src/main/java/com/kdt/team04/domain/matches/review/service/MatchRecordService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/review/service/MatchRecordService.java
@@ -11,9 +11,11 @@ import com.kdt.team04.domain.matches.match.model.MatchType;
 import com.kdt.team04.domain.matches.match.service.MatchGiverService;
 import com.kdt.team04.domain.matches.proposal.dto.response.FixedProposalResponse;
 import com.kdt.team04.domain.matches.proposal.service.MatchProposalGiverService;
+import com.kdt.team04.domain.matches.review.controller.QueryMatchRecordRequest;
 import com.kdt.team04.domain.matches.review.dto.MatchRecordConverter;
-import com.kdt.team04.domain.matches.review.model.entity.MatchRecord;
+import com.kdt.team04.domain.matches.review.dto.response.MatchRecordTotalResponse;
 import com.kdt.team04.domain.matches.review.model.MatchRecordValue;
+import com.kdt.team04.domain.matches.review.model.entity.MatchRecord;
 import com.kdt.team04.domain.matches.review.repository.MatchRecordRepository;
 import com.kdt.team04.domain.teams.team.dto.response.TeamSimpleResponse;
 import com.kdt.team04.domain.user.dto.response.AuthorResponse;
@@ -64,5 +66,9 @@ public class MatchRecordService {
 		}
 
 		matchRecordRepository.saveAll(records);
+	}
+
+	public MatchRecordTotalResponse findMatchRecordTotal(QueryMatchRecordRequest request) {
+		return matchRecordRepository.getTotalCount(request);
 	}
 }


### PR DESCRIPTION
## ✅  작업 단위

- [[DK-454] feat: 전적 조회 API 추가](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/41c56a33a475568ff693f406b50c0d13cf22252a)
  - 엔드포인트 /api/matches/records로 userId, teamId, sportCategory를 쿼리 파라미터로 받아 userId별, teamId별 sportCategory별 매치 전적 조회 기능을 추가했습니다.
  - teamId가 파라미터로 들어올 경우 userId를 무시합니다.(team 전적 조회 이므로)
  - userId만 들어올 경우 유저에 대한 전적 검사를 합니다.
  - sportsCategory가 없을 시 모든 종목에 대한 전적을 검색합니다.
  - teamId, userId 모두 없을 경우 validation Error를 발생합니다.

기존의 전적 검색 API 보다 이거를 쓰면 하나로 쓸 수 있지 않을까 싶어요
응답 Dto는 기존꺼를 재활용 했습니다.

[DK-454]: https://insta-kkyu.atlassian.net/browse/DK-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ