### PR TITLE
[DK-467]: 사용자 기준 신청 목록 조회 - 매칭 정보 조회 안되는 부분 수정

### DIFF
--- a/src/main/java/com/kdt/team04/domain/matches/match/repository/MatchRepository.java
+++ b/src/main/java/com/kdt/team04/domain/matches/match/repository/MatchRepository.java
@@ -10,6 +10,6 @@ import com.kdt.team04.domain.matches.match.model.entity.Match;
 
 public interface MatchRepository extends JpaRepository<Match, Long>, CustomMatchRepository {
 
-	@Query("SELECT m FROM Match m JOIN FETCH m.user JOIN FETCH m.team WHERE m.id IN (:ids)")
+	@Query("SELECT m FROM Match m JOIN FETCH m.user LEFT JOIN FETCH m.team WHERE m.id IN (:ids)")
 	List<Match> findWithTeamAndUserByIds(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
+++ b/src/main/java/com/kdt/team04/domain/matches/proposal/service/MatchProposalService.java
@@ -249,6 +249,7 @@ public class MatchProposalService {
 
 		List<Long> matchIds = proposals.stream()
 			.map(QueryProposalChatResponse::getMatchId)
+			.distinct()
 			.toList();
 
 		Map<Long, MatchResponse> matches = matchGiver.findByIds(matchIds);


### PR DESCRIPTION
## ✅  작업 단위

### [[DK-467] fix: 사용자 기준 신청 목록 조회 - 매칭 정보 조회 안되는 부분 수정](https://github.com/prgrms-web-devcourse/Team_04_SFam_BE/commit/38652ec8bb019cf3aaed7059ba75fb7310884dae)
- 동일한 Match ID 건 중복 제거 구문 추가
- 개인전인 경우에는 teamId가 null 일텐데, inner join 으로 되어 있어 개인전인 경우에는 조회가 안됬던 문제
  → left join 으로 변경 후 해결 완료

## 🤔 고민 했던 부분

- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🔊 HELP !!

- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

[DK-467]: https://insta-kkyu.atlassian.net/browse/DK-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ